### PR TITLE
Fixed Script Abort On Proxy Display message

### DIFF
--- a/src/helpers/chocolateyInstaller.psm1
+++ b/src/helpers/chocolateyInstaller.psm1
@@ -1,4 +1,4 @@
-helpersPath = (Split-Path -parent $MyInvocation.MyCommand.Definition);
+$helpersPath = (Split-Path -parent $MyInvocation.MyCommand.Definition);
 
 function Start-ChocolateyProcessAsAdmin {
 param([string] $statements, [string] $exeToRun = 'powershell')


### PR DESCRIPTION
I was using chocolatey behind an NTLM firewall and, after getting everything set up, the script kept breaking when outputting a message.  Simple fix, but makes a world of difference.

This is my first attempt at contrib'ing to a project on GitHub.  Please let me know if I failed in some way.
