### PR TITLE
Use DefaultCredentials instead of Get-Credentials when using proxy on web call

### DIFF
--- a/src/helpers/chocolateyInstaller.psm1
+++ b/src/helpers/chocolateyInstaller.psm1
@@ -560,11 +560,11 @@ param(
   $webclient = new-object System.Net.WebClient
   if (!$webclient.Proxy.IsBypassed($url))
   {
-    $cred = get-credential
+    $cred = [net.CredentialCache]::DefaultCredentials
     $proxyaddress = $webclient.Proxy.GetProxy($url).Authority
     Write-host "Using this proxyserver: $proxyaddress"
     $proxy = New-Object System.Net.WebProxy($proxyaddress)
-    $proxy.credentials = $cred.GetNetworkCredential();
+    $proxy.credentials = $cred
     $req.proxy = $proxy
   }
  


### PR DESCRIPTION
I have been noticing at work that I am prompted to enter my login for each downloaded file that the chocolatey installer downloads. This confuses some users gets in the way of the silent install experience. I have changed just a couple lines of code to use GetDefaultCredentils from the Credentials cache instead of calling Get-Credentials. I've had good luck with this technique in several different environments. This will basically justpass the windows token of the user to the proxy for authentication.
