### PR TITLE
improve pipelining for chocolatey-ver via obj

### DIFF
--- a/src/functions/Chocolatey-Version.ps1
+++ b/src/functions/Chocolatey-Version.ps1
@@ -63,6 +63,7 @@ param(
     Write-Host $verMessage
   }
   
-	$versions = @{latest = $versionLatest; found = $versionFound; latestCompare = $versionLatestCompare; foundCompare = $versionFoundCompare; }
-	return $versions
+	$versions = @{name=$package; latest = $versionLatest; found = $versionFound; latestCompare = $versionLatestCompare; foundCompare = $versionFoundCompare; }
+	$versionsObj = New-Object –typename PSObject -Property $versions
+	return $versionsObj
 }


### PR DESCRIPTION
- return an object of versions instead of a hash for improved pipelining capabilities
- usage via cmd:
  chocolatey version <package> "^|select name,found"
- usage via posh:
  .\chocolatey.ps1 version <package> |fl name,found
