### PR TITLE
Source config implementation

### DIFF
--- a/src/chocolatey.ps1
+++ b/src/chocolatey.ps1
@@ -1,7 +1,7 @@
 ﻿param(
   [string]$command,
   [string]$packageName='',
-  [string]$source='https://go.microsoft.com/fwlink/?LinkID=230477',
+  [string]$source='',
   [string]$version='',
   [alias("all")][switch] $allVersions = $false,
   [alias("ia","installArgs")][string] $installArguments = '',

--- a/src/functions/Chocolatey-Install.ps1
+++ b/src/functions/Chocolatey-Install.ps1
@@ -1,7 +1,7 @@
 ﻿function Chocolatey-Install {
 param(
   [string] $packageName, 
-  [string] $source = 'https://go.microsoft.com/fwlink/?LinkID=230477', 
+  [string] $source = '', 
   [string] $version = '',
   [string] $installerArguments = ''
 )

--- a/src/functions/Chocolatey-InstallIfMissing.ps1
+++ b/src/functions/Chocolatey-InstallIfMissing.ps1
@@ -1,7 +1,7 @@
 ﻿function Chocolatey-InstallIfMissing {
 param(
   [string] $packageName, 
-  [string] $source = 'https://go.microsoft.com/fwlink/?LinkID=230477',
+  [string] $source = '',
   [string] $version = ''
 )
   

--- a/src/functions/Chocolatey-List.ps1
+++ b/src/functions/Chocolatey-List.ps1
@@ -9,9 +9,7 @@ param(
     & cmd.exe $webpiArgs 
   } else {  
   
-    if ($source -ne '') {
-    	$srcArgs = "-Source `"$source`""
-    }
+  	$srcArgs = Get-SourceArgument $source
     
     $parameters = "list"
     if ($selector -ne '') {

--- a/src/functions/Chocolatey-List.ps1
+++ b/src/functions/Chocolatey-List.ps1
@@ -1,7 +1,7 @@
 ﻿function Chocolatey-List {
 param(
   [string] $selector='', 
-  [string] $source='https://go.microsoft.com/fwlink/?LinkID=230477' 
+  [string] $source='' 
 )
   
   if ($source -like 'webpi') {
@@ -9,9 +9,8 @@ param(
     & cmd.exe $webpiArgs 
   } else {  
   
-    $srcArgs = "-Source `"$source`""
-    if ($source -like 'https://go.microsoft.com/fwlink/?LinkID=230477') {
-      $srcArgs = "-Source `"http://chocolatey.org/api/v2/`" -Source `"$source`""
+    if ($source -ne '') {
+    	$srcArgs = "-Source `"$source`""
     }
     
     $parameters = "list"

--- a/src/functions/Chocolatey-NuGet.ps1
+++ b/src/functions/Chocolatey-NuGet.ps1
@@ -1,7 +1,7 @@
 ﻿function Chocolatey-NuGet { 
 param(
   [string] $packageName,
-  [string] $source = 'https://go.microsoft.com/fwlink/?LinkID=230477'
+  [string] $source = ''
 )
 
   if ($packageName -eq 'all') { 
@@ -9,14 +9,14 @@ param(
     return
   }
 
-  $srcArgs = "$source"
-  if ($source -like 'https://go.microsoft.com/fwlink/?LinkID=230477') {
-    $srcArgs = "http://chocolatey.org/api/v2/ OR $source"
+  $srcArgs = ""
+  if ($source -ne '') {
+    $srcArgs = "(from $source)"
   }
 
 @"
 $h1
-Chocolatey ($chocVer) is installing $packageName (from $srcArgs) to "$nugetLibPath". By installing you accept the license for the package you are installing (please run chocolatey /? for full license acceptance terms).
+Chocolatey ($chocVer) is installing $packageName $srcArgs to "$nugetLibPath". By installing you accept the license for the package you are installing (please run chocolatey /? for full license acceptance terms).
 $h1
 "@ | Write-Host
 

--- a/src/functions/Chocolatey-Push.ps1
+++ b/src/functions/Chocolatey-Push.ps1
@@ -5,9 +5,6 @@ param(
 )
 
   $srcArgs = "-source $source"
-  if ($source -like 'https://go.microsoft.com/fwlink/?LinkID=230477') {
-    $srcArgs = "-source http://chocolatey.org/"
-  }
 
   $packageArgs = "push $packageName $srcArgs"
   $logFile = Join-Path $nugetChocolateyPath 'push.log'

--- a/src/functions/Chocolatey-Update.ps1
+++ b/src/functions/Chocolatey-Update.ps1
@@ -1,7 +1,7 @@
 ﻿function Chocolatey-Update {
 param(
   [string] $packageName ='', 
-  [string] $source = 'https://go.microsoft.com/fwlink/?LinkID=230477'
+  [string] $source = ''
 )
 
   if ($packageName -eq '') {$packageName = 'chocolatey';}

--- a/src/functions/Chocolatey-Version.ps1
+++ b/src/functions/Chocolatey-Version.ps1
@@ -12,9 +12,7 @@ param(
     $packages = $packageFolders -replace "(\.\d{1,})+"|gu 
   }
   
-  if ($source -ne '') {
-  	$srcArgs = "-Source `"$source`""
-  }
+  $srcArgs = Get-SourceArgument $source
   
   foreach ($package in $packages) {
     $packageArgs = "list ""$package"" $srcArgs"

--- a/src/functions/Chocolatey-Version.ps1
+++ b/src/functions/Chocolatey-Version.ps1
@@ -1,7 +1,7 @@
 ﻿function Chocolatey-Version {
 param(
   [string] $packageName='',
-  [string] $source='https://go.microsoft.com/fwlink/?LinkID=230477'
+  [string] $source=''
 )
 
   if ($packageName -eq '') {$packageName = 'chocolatey';}
@@ -12,9 +12,8 @@ param(
     $packages = $packageFolders -replace "(\.\d{1,})+"|gu 
   }
   
-  $srcArgs = "-Source `"$source`""
-  if ($source -like 'https://go.microsoft.com/fwlink/?LinkID=230477') {
-    $srcArgs = "-Source `"http://chocolatey.org/api/v2/`" -Source `"$source`""
+  if ($source -ne '') {
+  	$srcArgs = "-Source `"$source`""
   }
   
   foreach ($package in $packages) {

--- a/src/functions/Get-SourceArgument.ps1
+++ b/src/functions/Get-SourceArgument.ps1
@@ -1,0 +1,26 @@
+﻿function Get-SourceArgument {
+param(
+  [string] $source = ''
+)
+	$srcArgs = ""
+	if ($source -ne '') {
+		$srcArgs = "-Source `"$source`""
+	}
+	else
+	{
+		$useNugetConfig = Get-ConfigValue 'useNuGetForSources'
+		
+		if ($useNugetConfig -eq 'false') {
+			$sources = Get-ConfigValue 'sources'
+	
+			foreach ($sourceEntry in $sources.ChildNodes) {
+				$srcUri = $sourceEntry.value
+				$srcArgs = $srcArgs + "-Source `"$srcUri`" "
+			}
+		}
+	}
+	
+	Write-Debug "Source args: $srcArgs"
+
+	$srcArgs
+}

--- a/src/functions/Run-NuGet.ps1
+++ b/src/functions/Run-NuGet.ps1
@@ -1,7 +1,7 @@
 ﻿function Run-NuGet {
 param(
   [string] $packageName, 
-  [string] $source = 'https://go.microsoft.com/fwlink/?LinkID=230477',
+  [string] $source = '',
   [string] $version = ''
 )
 @"
@@ -10,13 +10,8 @@ NuGet
 $h2
 "@ | Write-Debug
 
-  $srcArgs = "-Source `"$source`""
-  if ($source -like 'https://go.microsoft.com/fwlink/?LinkID=230477') {
-    $srcArgs = "-Source `"http://chocolatey.org/api/v2/`" -Source `"$source`""
-  }
-
-  if ($source -like '') {
-    $srcArgs = "-Source `"http://chocolatey.org/api/v2/`" -Source `"https://go.microsoft.com/fwlink/?LinkID=230477`""
+  if ($source -ne '') {
+  	$srcArgs = "-Source `"$source`""
   }
 
   $packageArgs = "install $packageName -Outputdirectory `"$nugetLibPath`" $srcArgs"

--- a/src/functions/Run-NuGet.ps1
+++ b/src/functions/Run-NuGet.ps1
@@ -10,9 +10,7 @@ NuGet
 $h2
 "@ | Write-Debug
 
-  if ($source -ne '') {
-  	$srcArgs = "-Source `"$source`""
-  }
+  	$srcArgs = Get-SourceArgument $source
 
   $packageArgs = "install $packageName -Outputdirectory `"$nugetLibPath`" $srcArgs"
   if ($version -notlike '') {


### PR DESCRIPTION
I have removed the source argument defaults used in all the functions.
I have added a new Get-SourceArgument function to wrap the logic for handling the source argument generation.
This new function is then used in Chocolatey-List, Chocolatey-Version, and Run-Get functions.

Basic logic used in Get-SourceArgument:
- if the user supplied a source, use it
- if the useNuGetForSources flag is true, do not set the source argument, which will let NuGet handle it.
- otherwise read the sources out of the chocolatey.config file and use those.
