### PR TITLE
Update Install-ChocolateyPackage to check for cached package installers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# build nuget packages
+*.nupkg

--- a/Graphviz/Graphviz.2.28.0.nuspec
+++ b/Graphviz/Graphviz.2.28.0.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <version>2.28.0</version>
+    <authors>Arif Bilgin,graphviz committers</authors>
+    <owners>Jason Denizac</owners>
+    <licenseUrl>http://www.graphviz.org/License.php</licenseUrl>
+    <projectUrl>http://www.graphviz.org/</projectUrl>
+    <iconUrl>http://www.graphviz.org/app.png</iconUrl>
+    <id>Graphviz</id>
+    <title>Graphviz - Graph Visualization Software</title>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>The Graphviz layout programs take descriptions of graphs in a simple text language, and make diagrams in useful formats, such as images and SVG for web pages, PDF or Postscript for inclusion in other documents; or display in an interactive graph browser. (Graphviz also supports GXL, an XML dialect.)</description>
+    <summary>Eclipse Public License - v 1.0</summary>
+    <tags>drawing, graph, visualization</tags>
+  </metadata>
+</package>

--- a/Graphviz/tools/chocolateyInstall.ps1
+++ b/Graphviz/tools/chocolateyInstall.ps1
@@ -1,0 +1,1 @@
+Install-ChocolateyPackage 'Graphviz' 'msi' '/passive' 'http://www.graphviz.org/pub/graphviz/stable/windows/graphviz-2.28.0.msi'

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,2 @@
+#ChocoPackages
+These are some Chcocolatey packages I maintain. Chocolatey is a binary package manager for Windows.


### PR DESCRIPTION
The Install-ChocolateyPackage helper downloads package installers to a local temp directory. This patch adds a quick check to see if the file exists in the temp directory before downloading it again. This changes the temp file name to include the remote file name to help prevent name collisions between different versions of installers.

Some installers are rather large, and saving them helps save time and bandwidth, and possibly working towards a complete offline-accessible mode as discussed in [Hanselman's blog post on working with NuGet offline](http://www.hanselman.com/blog/HowToAccessNuGetWhenNuGetorgIsDownOrYoureOnAPlane.aspx).

This is my first Chocolatey pull request, so please let me know if there's anything else I should do to meet the project standards.
