### PR TITLE
Multiple sources

### DIFF
--- a/src/chocolatey.ps1
+++ b/src/chocolatey.ps1
@@ -1,7 +1,7 @@
 ﻿param(
   [string]$command,
   [string]$packageName='',
-  [string]$source='',
+  [string[]]$source='',
   [string]$version='',
   [alias("all")][switch] $allVersions = $false,
   [alias("ia","installArgs")][string] $installArguments = '',

--- a/src/functions/Chocolatey-Install.ps1
+++ b/src/functions/Chocolatey-Install.ps1
@@ -1,7 +1,7 @@
 ﻿function Chocolatey-Install {
 param(
   [string] $packageName, 
-  [string] $source = '', 
+  [string[]] $source = '', 
   [string] $version = '',
   [string] $installerArguments = ''
 )

--- a/src/functions/Chocolatey-InstallIfMissing.ps1
+++ b/src/functions/Chocolatey-InstallIfMissing.ps1
@@ -1,7 +1,7 @@
 ﻿function Chocolatey-InstallIfMissing {
 param(
   [string] $packageName, 
-  [string] $source = '',
+  [string[]] $source = '',
   [string] $version = ''
 )
   

--- a/src/functions/Chocolatey-List.ps1
+++ b/src/functions/Chocolatey-List.ps1
@@ -1,7 +1,7 @@
 ﻿function Chocolatey-List {
 param(
   [string] $selector='', 
-  [string] $source='' 
+  [string[]] $source='' 
 )
   
   if ($source -like 'webpi') {

--- a/src/functions/Chocolatey-NuGet.ps1
+++ b/src/functions/Chocolatey-NuGet.ps1
@@ -1,7 +1,7 @@
 ﻿function Chocolatey-NuGet { 
 param(
   [string] $packageName,
-  [string] $source = ''
+  [string[]] $source = ''
 )
 
   if ($packageName -eq 'all') { 

--- a/src/functions/Chocolatey-Update.ps1
+++ b/src/functions/Chocolatey-Update.ps1
@@ -1,7 +1,7 @@
 ﻿function Chocolatey-Update {
 param(
   [string] $packageName ='', 
-  [string] $source = ''
+  [string[]] $source = ''
 )
 
   if ($packageName -eq '') {$packageName = 'chocolatey';}

--- a/src/functions/Chocolatey-Version.ps1
+++ b/src/functions/Chocolatey-Version.ps1
@@ -1,7 +1,7 @@
 ﻿function Chocolatey-Version {
 param(
   [string] $packageName='',
-  [string] $source=''
+  [string[]] $source=''
 )
 
   if ($packageName -eq '') {$packageName = 'chocolatey';}

--- a/src/functions/Get-SourceArguments.ps1
+++ b/src/functions/Get-SourceArguments.ps1
@@ -1,10 +1,11 @@
 ﻿function Get-SourceArguments {
 param(
-  [string] $source = ''
+  [string[]] $source = ''
 )
+    
 	$srcArgs = ""
 	if ($source -ne '') {
-		$srcArgs = "-Source `"$source`""
+		$srcArgs = "-Source `"" + ($source -join ";") + "`""
 	}
 	else
 	{

--- a/src/functions/Run-NuGet.ps1
+++ b/src/functions/Run-NuGet.ps1
@@ -1,7 +1,7 @@
 ﻿function Run-NuGet {
 param(
   [string] $packageName, 
-  [string] $source = '',
+  [string[]] $source = '',
   [string] $version = ''
 )
 @"


### PR DESCRIPTION
This change addresses issue 105, support for multiple sources. Here is an example of its use:

clist blah -source "http://sourceOne,http://sourceTwo"

That is a comma separated list of sources. The sources can be URLs, folders paths, or source names (from the nuget config). This leverages the existing support for multiple sources already in NuGet. It just translates the comma delimited list used by powershell to the semi-colon list used by NuGet.
