### PR TITLE
[Enhancement] Feature cver remotecheck

### DIFF
--- a/src/chocolatey.ps1
+++ b/src/chocolatey.ps1
@@ -9,8 +9,9 @@
   [switch] $overrideArgs = $false,
   [switch] $force = $false,
   [alias("pre")][switch] $prerelease = $false,
+  [alias("lo")][switch] $localonly = $false,
   [switch] $debug
-) 
+  ) 
 
 # chocolatey
 # Copyright (c) 2011-Present Rob Reynolds


### PR DESCRIPTION
cver all is slow.  this is one way to assist in a specific local query scenario.

note - This includes the changes in PR 118 (recommend that 1 first and I'll rebase).   It adds an optional param that can be used on cver to instantly get all the local version numbers without running nuget (slower) process.  This can assist for queries with param 'all'  when large numbers of packages are present, but you are only interested in the packages local versions numbers

another idea - start process nuget occurs inside foreach package loop.  it would be nice to add threading to this.

motivation - the future puppet provider needs to query all installed packages.  it doesn't make sense for it to take "minutes"
