### PR TITLE
Version Info for each package

### DIFF
--- a/src/functions/Chocolatey-Version.ps1
+++ b/src/functions/Chocolatey-Version.ps1
@@ -59,9 +59,11 @@ param(
       $verMessage = "$package does not appear to be on the source(s) specified: `'$srcArgs`' (if value is empty, using sources in nuget.config file). You have $versionFound installed. Interesting..."
     }
     Write-Host $verMessage
-  }
-  
+	
 	$versions = @{name=$package; latest = $versionLatest; found = $versionFound; latestCompare = $versionLatestCompare; foundCompare = $versionFoundCompare; }
 	$versionsObj = New-Object –typename PSObject -Property $versions
-	return $versionsObj
+	
+	#return version object for each package
+	$versionsObj
+  }
 }


### PR DESCRIPTION
Needed to programmatically access the version info for each object when running `chocolatey version all`. Previously the `$versionsObj` was only being returned if a single package was specified. Now I am able to do this: `cver all | & { "$($_.Name), $($_.Found)" }`. I stumbled across this when trying to use the [https://github.com/rismoney/puppet-chocolatey](chocolatey package provider for puppet).
