### PR TITLE
[Enhancement] Function to associate file extensions with installed executables

### DIFF
--- a/src/helpers/chocolateyInstaller.psm1
+++ b/src/helpers/chocolateyInstaller.psm1
@@ -9,4 +9,4 @@ Resolve-Path $helpersPath\functions\*.ps1 |
     ? { -not ($_.ProviderPath.Contains(".Tests.")) } |
     % { . $_.ProviderPath }
 
-Export-ModuleMember -Function Start-ChocolateyProcessAsAdmin, Install-ChocolateyPackage, Uninstall-ChocolateyPackage, Install-ChocolateyZipPackage, Install-ChocolateyPowershellCommand, Get-ChocolateyWebFile, Install-ChocolateyInstallPackage, Get-ChocolateyUnzip, Write-ChocolateySuccess, Write-ChocolateyFailure, Install-ChocolateyPath, Install-ChocolateyDesktopLink, Write-Host, Write-Error
+Export-ModuleMember -Function Start-ChocolateyProcessAsAdmin, Install-ChocolateyPackage, Uninstall-ChocolateyPackage, Install-ChocolateyZipPackage, Install-ChocolateyPowershellCommand, Get-ChocolateyWebFile, Install-ChocolateyInstallPackage, Get-ChocolateyUnzip, Write-ChocolateySuccess, Write-ChocolateyFailure, Install-ChocolateyPath, Install-ChocolateyDesktopLink, Write-Host, Write-Error, Install-ChocolateyFileAssociation

--- a/src/helpers/functions/Install-ChocolateyFileAssociation.ps1
+++ b/src/helpers/functions/Install-ChocolateyFileAssociation.ps1
@@ -1,0 +1,21 @@
+function Install-ChocolateyFileAssociation {
+param(
+  [string] $extension,
+  [string] $executable
+)
+  Write-Debug "Running 'Install-ChocolateyFileAssociation' associating $extension with `'$executable`'";
+  if(-not(Test-Path $executable)){
+    $errorMessage = "`'$executable`' does not exist, not able to create association"
+    Write-Error $errorMessage
+    throw $errorMessage
+  }
+  $extension=$extension.trim()
+  if(-not($extension.StartsWith("."))) {
+      $extension = ".$extension"
+  }
+  $fileType = Split-Path $executable -leaf
+  $fileType = $fileType.Replace(" ","_")
+  $elevated = "cmd /c 'assoc $extension=$fileType';cmd /c 'ftype $fileType=\`"$executable\`" \`"%1\`" \`"%*\`"'"
+  Start-ChocolateyProcessAsAdmin $elevated
+  Write-Host "`'$extension`' has been associated with `'$executable`'"
+}

--- a/tests/_Common.ps1
+++ b/tests/_Common.ps1
@@ -6,7 +6,7 @@ $setup = Join-Path $here '_Setup.ps1'
 $initializeVariables = Join-Path $here '_Initialize-Variables.ps1'
 $installModule = Join-Path (Join-Path $src 'helpers') 'chocolateyInstaller.psm1'
 
-Import-Module $installModule -Function Start-ChocolateyProcessAsAdmin, Install-ChocolateyPackage, Install-ChocolateyZipPackage, Install-ChocolateyPowershellCommand, Get-ChocolateyWebFile, Install-ChocolateyInstallPackage, Get-ChocolateyUnzip, Write-ChocolateySuccess, Write-ChocolateyFailure, Install-ChocolateyPath, Install-ChocolateyDesktopLink
+Import-Module $installModule -Function Start-ChocolateyProcessAsAdmin, Install-ChocolateyPackage, Install-ChocolateyZipPackage, Install-ChocolateyPowershellCommand, Get-ChocolateyWebFile, Install-ChocolateyInstallPackage, Get-ChocolateyUnzip, Write-ChocolateySuccess, Write-ChocolateyFailure, Install-ChocolateyPath, Install-ChocolateyDesktopLink, Install-ChocolateyFileAssociation
 
 Import-Module $script 
 Import-Module $functionRenames

--- a/tests/_FunctionRenameActuals.ps1
+++ b/tests/_FunctionRenameActuals.ps1
@@ -32,6 +32,7 @@ rename-item function:Get-ChocolateyUnzip Get-ChocolateyUnzip-Actual
 rename-item function:Get-ChocolateyWebFile Get-ChocolateyWebFile-Actual
 #rename-item function:Get-WebFile Get-WebFile-Actual
 rename-item function:Install-ChocolateyDesktopLink Install-ChocolateyDesktopLink-Actual
+rename-item function:Install-ChocolateyFileAssociation Install-ChocolateyFileAssociation-Actual
 rename-item function:Install-ChocolateyInstallPackage Install-ChocolateyInstallPackage-Actual
 rename-item function:Install-ChocolateyPackage Install-ChocolateyPackage-Actual
 rename-item function:Install-ChocolateyPath Install-ChocolateyPath-Actual

--- a/tests/_Initialize-Variables.ps1
+++ b/tests/_Initialize-Variables.ps1
@@ -18,7 +18,8 @@
   $script:path = ''
   $script:configValue = ''
   $script:action = ''
- 
+  $script:extension = ''
+  
   # function calls
   $script:chocolatey_install_was_called = $false
   $script:chocolatey_installall_was_called = $false
@@ -52,6 +53,7 @@
   $script:get_chocolateywebfile_was_called = $false
   $script:get_webfile_was_called = $false
   $script:install_chocolateydesktoplink_was_called = $false
+  $script:install_ChocolateyFileAssociation_was_called = $false  
   $script:install_chocolateyinstallpackage_was_called = $false
   $script:install_chocolateypackage_was_called = $false
   $script:install_chocolateypath_was_called = $false
@@ -136,6 +138,7 @@
   $script:exec_get_chocolateywebfile_actual = $false
   $script:exec_get_webfile_actual = $false
   $script:exec_install_chocolateydesktoplink_actual = $false
+  $script:exec_install_chocolateyfileassociation_actual = $false  
   $script:exec_install_chocolateyinstallpackage_actual = $false
   $script:exec_install_chocolateypackage_actual = $false
   $script:exec_install_chocolateypath_actual = $false

--- a/tests/helpers/Install-ChocolateyFileAssociation.ps1
+++ b/tests/helpers/Install-ChocolateyFileAssociation.ps1
@@ -1,0 +1,12 @@
+function Install-ChocolateyFileAssociation {
+param(
+  [string] $extension,
+  [string] $executable
+)
+
+  $script:install_ChocolateyFileAssociation_was_called = $true
+  $script:extension = $extension
+  $script:executable = $executable  
+  
+  if ($script:exec_install_ChocolateyFileAssociation_actual) { Install-ChocolateyFileAssociation-Actual @PSBoundParameters}
+}


### PR DESCRIPTION
This will elevate to admin and associate a file extension with a executable.

Usage Install-ChocolateyFileAssociation -extension <file extension> -executable <path to executable>
- The executable must exist. 
- If there is no preceeding '.' in the extension, one will be added
- If only '.' is entered as the extension then the executable will be associated with all UNassociated file types.
- The executable will be invoked as <executable path> "%1" "%*" %1 will be the associated file and %* will be all/any arguments.
