### PR TITLE
Fix for "Execution of NuGet not detected" error.

### DIFF
--- a/src/functions/Run-NuGet.ps1
+++ b/src/functions/Run-NuGet.ps1
@@ -44,7 +44,7 @@ $h2
   foreach ($line in $nugetOutput) {
     if ($line -ne $null) {Write-Debug $line;}
   }
-  $errors = Get-Content $errorLogFile
+
   if ($errors -ne '') {
     Write-Host $errors -BackgroundColor Red -ForegroundColor White
     #Throw $errors

--- a/src/functions/Run-NuGet.ps1
+++ b/src/functions/Run-NuGet.ps1
@@ -24,9 +24,23 @@ $h2
   $logFile = Join-Path $nugetChocolateyPath 'install.log'
   $errorLogFile = Join-Path $nugetChocolateyPath 'error.log'
   Write-Debug "Calling NuGet.exe $packageArgs"
-  Start-Process $nugetExe -ArgumentList $packageArgs -NoNewWindow -Wait -RedirectStandardOutput $logFile -RedirectStandardError $errorLogFile
 
-  $nugetOutput = Get-Content $logFile -Encoding Ascii
+  $process = New-Object system.Diagnostics.Process
+  $process.StartInfo = new-object System.Diagnostics.ProcessStartInfo($nugetExe, $packageArgs)
+  $process.StartInfo.RedirectStandardOutput = $true
+  $process.StartInfo.RedirectStandardError = $true
+  $process.StartInfo.UseShellExecute = $false
+
+  $process.Start()
+  $process.WaitForExit()
+
+  $nugetOutput = $process.StandardOutput.ReadToEnd()
+  $errors = $process.StandardError.ReadToEnd()
+
+
+  $nugetOutput | Out-File $logFile
+  $errors | Out-File $errorLogFile
+
   foreach ($line in $nugetOutput) {
     if ($line -ne $null) {Write-Debug $line;}
   }


### PR DESCRIPTION
Using the Start-Process cmdlet with -RedirectStandardOutput does not
reliably flush output to the file immediately.  This causes the text
file that the script immediately tries to read afterwards to sometimes
be empty.  This manifests as the "Execution of NuGet not detected" error
and I suspect is the cause of this issue on certain systems that many
users are seeing.
