### PR TITLE
[Enhancement] Ability to override bootstrapper url

### DIFF
--- a/chocolateyInstall/InstallChocolatey.ps1
+++ b/chocolateyInstall/InstallChocolatey.ps1
@@ -17,9 +17,7 @@
 # ==============================================================================
 
 # variables
-#$url = "http://chocolatey.org/packages/chocolatey/DownloadPackage"
-$url = "http://chocolatey.org/api/v2/package/chocolatey/"
-#$url = "http://chocolatey.org/api/v1/package/chocolatey"
+if(!$url){$url = "http://chocolatey.org/api/v2/package/chocolatey/"}
 $chocTempDir = Join-Path $env:TEMP "chocolatey"
 $tempDir = Join-Path $chocTempDir "chocInstall"
 if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}


### PR DESCRIPTION
Adding thias as a pull request because it touches the "LIVE" installer. Feels harmless but I'd like a review. The point is I want to call the chocolatey installer but pull down a different url like the alpha or a prealpha.
