### PR TITLE
[Enhancement] add -verbose switch for clist support to see package description

### DIFF
--- a/src/chocolatey.ps1
+++ b/src/chocolatey.ps1
@@ -10,6 +10,7 @@
   [switch] $force = $false,
   [alias("pre")][switch] $prerelease = $false,
   [alias("lo")][switch] $localonly = $false,
+  [alias("verbose")][switch] $verbosity = $false,
   [switch] $debug,
   [string] $name
 )

--- a/src/functions/Chocolatey-List.ps1
+++ b/src/functions/Chocolatey-List.ps1
@@ -37,6 +37,10 @@ param(
       $parameters = "$parameters -Prerelease";
     }
     
+    if ($verbosity -eq $true) {
+      $parameters = "$parameters -verbose";
+    }
+
     Write-Debug "Calling nuget with `'$parameters $srcArgs`'"
     $parameters = "$parameters $srcArgs"
 


### PR DESCRIPTION
added verbose switch for chocolatey list.  This way you can see what the package description is at the command line.

usage: clist <packagename> -verbose
