### PR TITLE
add rudimentary functionality to mimic whatprovides

### DIFF
--- a/nuget/tools/chocolateysetup.psm1
+++ b/nuget/tools/chocolateysetup.psm1
@@ -40,7 +40,8 @@ $nugetChocolateyListAlias = Join-Path $chocolateyExePath 'clist.bat'
 $nugetChocolateyVersionAlias = Join-Path $chocolateyExePath 'cver.bat'
 $nugetChocolateyPackAlias = Join-Path $chocolateyExePath 'cpack.bat'
 $nugetChocolateyPushAlias = Join-Path $chocolateyExePath 'cpush.bat'
-
+$nugetChocolateyUninstallAlias = Join-Path $chocolateyExePath 'cuninst.bat'
+$nugetChocolateyProvidesAlias = Join-Path $chocolateyExePath 'cprovides.bat'
 
 Write-Host "Creating `'$nugetChocolateyBinFile`' so you can call 'chocolatey' from anywhere."
 "@echo off
@@ -114,6 +115,7 @@ SET DIR=%~dp0%
 ""`$SYSTEMROOT/System32/cmd.exe"" /c ""`$(basename $0).bat `$*""
 exit `$?" | Out-File $nugetChocolateyPushAlias.Replace(".bat","") -encoding ASCII 
 
+
 Write-Host "Creating `'$nugetChocolateyUninstallAlias`' so you can call 'chocolatey uninstall' from a shortcut of 'cuninst'."
 "@echo off
 SET DIR=%~dp0%
@@ -122,6 +124,16 @@ SET DIR=%~dp0%
 "#!/bin/sh
 ""`$SYSTEMROOT/System32/cmd.exe"" /c ""`$(basename $0).bat `$*""
 exit `$?" | Out-File $nugetChocolateyUninstallAlias.Replace(".bat","") -encoding ASCII 
+
+
+Write-Host "Creating `'$nugetChocolateyProvidesAlias`' so you can call 'chocolatey whatprovides' from a shortcut of 'cprovides'."
+"@echo off
+SET DIR=%~dp0%
+""$nugetChocolateyPath\chocolatey.cmd"" whatprovides %*" | Out-File $nugetChocolateyProvidesAlias -encoding ASCII
+
+"#!/bin/sh
+""`$SYSTEMROOT/System32/cmd.exe"" /c ""`$(basename $0).bat `$*""
+exit `$?" | Out-File $nugetChocolateyProvidesAlias.Replace(".bat","") -encoding ASCII 
 
 }
 

--- a/src/chocolatey.ps1
+++ b/src/chocolatey.ps1
@@ -82,6 +82,7 @@ switch -wildcard ($command)
   "search" { Chocolatey-List $packageName $source; }
   "list" { Chocolatey-List $packageName $source; }
   "version" { Chocolatey-Version $packageName $source; }
+  "whatprovides" { Chocolatey-WhatProvides $packageName; }
   "webpi" { Chocolatey-WebPI $packageName $installArguments; }
   "windowsfeatures" { Chocolatey-WindowsFeatures $packageName; }
   "cygwin" { Chocolatey-Cygwin $packageName $installArguments; }

--- a/src/functions/Chocolatey-WhatProvides.ps1
+++ b/src/functions/Chocolatey-WhatProvides.ps1
@@ -1,0 +1,6 @@
+function Chocolatey-WhatProvides {
+param(
+  [string] $fileName=''
+)
+gci -Path C:\chocolatey\lib\ -Filter *.txt -Recurse | select-string $filename |fw path -Column 1
+}


### PR DESCRIPTION
currently only works for zip files
additional functionality will be added for msi later
relies on *.txt files in lib as source

usage: cprovides file.exe it should report which package and packagename it originated from.  good for finding duplicate files installed from multiple packages
