### PR TITLE
Support for custom headers downloading files

### DIFF
--- a/src/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -34,7 +34,8 @@ param(
   [string] $packageName,
   [string] $fileFullPath,
   [string] $url,
-  [string] $url64bit = $url
+  [string] $url64bit = $url,
+  [hashtable] $options = @{Headers=@{}}
 )
   Write-Debug "Running 'Get-ChocolateyWebFile' for $packageName with url:`'$url`', fileFullPath:`'$fileFullPath`',and url64bit:`'$url64bit`'";
   
@@ -60,7 +61,7 @@ param(
   #$downloader = new-object System.Net.WebClient
   #$downloader.DownloadFile($url, $fileFullPath)
   if ($url.StartsWith('http')) {
-    Get-WebFile $url $fileFullPath
+    Get-WebFile $url $fileFullPath -options $options
   } elseif ($url.StartsWith('ftp')) {
     Get-FtpFile $url $fileFullPath
   } else {

--- a/src/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -20,6 +20,24 @@ This is the url to download the file from.
 .PARAMETER Url64bit
 OPTIONAL - If there is an x64 installer to download, please include it here. If not, delete this parameter
 
+.PARAMETER options
+OPTIONAL - Specify custom headers
+
+Example:
+-------- 
+	$options = 
+	@{
+		Headers = @{
+			Accept = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'; 
+			'Accept-Charset' = 'ISO-8859-1,utf-8;q=0.7,*;q=0.3';
+			'Accept-Language' = 'en-GB,en-US;q=0.8,en;q=0.6';
+			Cookie = 'products.download.email=ewilde@gmail.com';
+			Referer = 'http://submain.com/download/ghostdoc/';
+		}
+	}
+	
+	Get-ChocolateyWebFile 'ghostdoc' 'http://submain.com/download/GhostDoc_v4.0.zip' -options $options
+
 .EXAMPLE
 Get-ChocolateyWebFile '__NAME__' 'C:\somepath\somename.exe' 'URL' '64BIT_URL_DELETE_IF_NO_64BIT'
 

--- a/src/helpers/functions/Get-WebFile.ps1
+++ b/src/helpers/functions/Get-WebFile.ps1
@@ -18,7 +18,7 @@ function Get-WebFile {
 param(
   $url = '', #(Read-Host "The URL to download"),
   $fileName = $null,
-  $userAgent = $null,
+  $userAgent = 'chocolatey command line',
   [hashtable] $options = @{Headers=@{}},
   [switch]$Passthru,
   [switch]$quiet

--- a/src/helpers/functions/Get-WebFile.ps1
+++ b/src/helpers/functions/Get-WebFile.ps1
@@ -18,7 +18,8 @@ function Get-WebFile {
 param(
   $url = '', #(Read-Host "The URL to download"),
   $fileName = $null,
-  $userAgent = 'chocolatey command line',
+  $userAgent = $null,
+  [hashtable] $options = @{Headers=@{}},
   [switch]$Passthru,
   [switch]$quiet
 )
@@ -47,6 +48,21 @@ param(
   if ($userAgent -ne $null) {
     Write-Debug "Setting the UserAgent to `'$userAgent`'"
     $req.UserAgent = $userAgent
+  }
+  
+  if ($options.Headers.Count -gt 0) {
+	Write-Debug "Setting custom headers"    
+	foreach ($item in $options.Headers.GetEnumerator()) {
+		$uri = (new-object system.uri $url)
+		Write-Debug($item.Key + ':' + $item.Value)
+		switch ($item.Key) {
+			'Accept' {$req.Accept = $item.Value}
+			'Cookie' {$req.CookieContainer.SetCookies($uri, $item.Value)}
+			'Referer' {$req.Referer = $item.Value}
+			'User-Agent' {$req.UserAgent = $item.Value}
+			Default {$req.Headers.Add($item.Key, $item.Value)}
+		}
+	}
   }
   $res = $req.GetResponse();
 

--- a/src/helpers/functions/Install-ChocolateyPackage.ps1
+++ b/src/helpers/functions/Install-ChocolateyPackage.ps1
@@ -47,6 +47,7 @@ param(
   [string] $silentArgs = '',
   [string] $url,
   [string] $url64bit = $url,
+  [hashtable] $options = @{Headers=@{}},
   $validExitCodes = @(0)
 )
   
@@ -58,7 +59,7 @@ param(
     if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
     $file = Join-Path $tempDir "$($packageName)Install.$fileType"
   
-    Get-ChocolateyWebFile $packageName $file $url $url64bit
+    Get-ChocolateyWebFile $packageName $file $url $url64bit -options $options
     Install-ChocolateyInstallPackage $packageName $fileType $silentArgs $file -validExitCodes $validExitCodes
     Write-ChocolateySuccess $packageName
   } catch {

--- a/src/helpers/functions/Install-ChocolateyPackage.ps1
+++ b/src/helpers/functions/Install-ChocolateyPackage.ps1
@@ -27,6 +27,24 @@ This is the url to download the file from.
 .PARAMETER Url64bit
 OPTIONAL - If there is an x64 installer to download, please include it here. If not, delete this parameter
 
+.PARAMETER options
+OPTIONAL - Specify custom headers
+
+Example:
+-------- 
+	$options = 
+	@{
+		Headers = @{
+			Accept = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'; 
+			'Accept-Charset' = 'ISO-8859-1,utf-8;q=0.7,*;q=0.3';
+			'Accept-Language' = 'en-GB,en-US;q=0.8,en;q=0.6';
+			Cookie = 'products.download.email=ewilde@gmail.com';
+			Referer = 'http://submain.com/download/ghostdoc/';
+		}
+	}
+	
+	Get-ChocolateyWebFile 'ghostdoc' 'http://submain.com/download/GhostDoc_v4.0.zip' -options $options
+	
 .EXAMPLE
 Install-ChocolateyPackage '__NAME__' 'EXE_OR_MSI' 'SILENT_ARGS' 'URL' '64BIT_URL_DELETE_IF_NO_64BIT'
 

--- a/src/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -38,7 +38,8 @@ param(
   [string] $url,
   [string] $unzipLocation,
   [string] $url64bit = $url,
-  [string] $specificFolder =""
+  [string] $specificFolder ="",
+  [hashtable] $options = @{Headers=@{}}
 )
   Write-Debug "Running 'Install-ChocolateyZipPackage' for $packageName with url:`'$url`', unzipLocation: `'$unzipLocation`', url64bit: `'$url64bit`' ";
   
@@ -50,7 +51,7 @@ param(
     if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
     $file = Join-Path $tempDir "$($packageName)Install.$fileType"
     
-    Get-ChocolateyWebFile $packageName $file $url $url64bit
+    Get-ChocolateyWebFile $packageName $file $url $url64bit -options $options
     Get-ChocolateyUnzip "$file" $unzipLocation $specificFolder $packageName
     
     Write-ChocolateySuccess $packageName

--- a/src/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -19,6 +19,24 @@ OPTIONAL - If there is an x64 installer to download, please include it here. If 
 .PARAMETER UnzipLocation
 This is a location to unzip the contents to, most likely your script folder.
 
+.PARAMETER options
+OPTIONAL - Specify custom headers
+
+Example:
+-------- 
+	$options = 
+	@{
+		Headers = @{
+			Accept = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'; 
+			'Accept-Charset' = 'ISO-8859-1,utf-8;q=0.7,*;q=0.3';
+			'Accept-Language' = 'en-GB,en-US;q=0.8,en;q=0.6';
+			Cookie = 'products.download.email=ewilde@gmail.com';
+			Referer = 'http://submain.com/download/ghostdoc/';
+		}
+	}
+	
+	Get-ChocolateyWebFile 'ghostdoc' 'http://submain.com/download/GhostDoc_v4.0.zip' -options $options
+	
 .EXAMPLE
 Install-ChocolateyZipPackage '__NAME__' 'URL' "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 


### PR DESCRIPTION
Some web sites require specific headers to allow you to download the
setup program/zip

functions:
Get-WebFile.ps1
Get-ChocolateyWebFile.ps1
Install-ChocolateyPackage.ps1
Install-ChocolateyZipPackage.ps1

now support an options hashtable which allows use to specify individual
headers.

The options hash table structure allows for future settings to be flowed through the application without updating multiple method signatures.

The structure at the moment is:
<pre> 
$options = @ {
   Headers = @{
      Header1 = 'somevalue'; Header2 = 'somevalue'
 }
}
</pre>
In the future you could use the options to pass down cookies by domain for example
<pre> 
$options = @ {
   Headers = @{
      Header1 = 'somevalue'; Header2 = 'somevalue'
   };
   Cookies = @{
      'http://domain.com' = 'value1';
      'http://secure.domain.com = 'value2';
   }   
}

</pre> 