### PR TITLE
[Enhancement] fix downloads greater than 2GB

### DIFF
--- a/src/helpers/functions/Get-WebFile.ps1
+++ b/src/helpers/functions/Get-WebFile.ps1
@@ -76,13 +76,13 @@ param(
   }
 
   if($res.StatusCode -eq 200) {
-    [int]$goal = $res.ContentLength
+    [long]$goal = $res.ContentLength
     $reader = $res.GetResponseStream()
     if($fileName) {
        $writer = new-object System.IO.FileStream $fileName, "Create"
     }
     [byte[]]$buffer = new-object byte[] 4096
-    [int]$total = [int]$count = 0
+    [long]$total = [long]$count = 0
     do
     {
        $count = $reader.Read($buffer, 0, $buffer.Length);


### PR DESCRIPTION
32 bit integer yields error if file size is greater than 2GB.  Switched var to 64 bit length to accomodate larger file size.  

Buffer is still 4096 which should be upped to some high #, not 100% sure how to tune.  I run at 10485760 (1024x1024) which is much faster, but not sure if I am over comp
