### PR TITLE
[Enhancement] Making the unzip process silent as there is no reason to display a progr...

### DIFF
--- a/src/helpers/functions/Get-ChocolateyUnzip.ps1
+++ b/src/helpers/functions/Get-ChocolateyUnzip.ps1
@@ -51,7 +51,7 @@ param(
   $zipPackage = $shellApplication.NameSpace($fileFullPath) 
   $destinationFolder = $shellApplication.NameSpace($destination)
   $zipPackageItems = $zipPackage.Items()
-  $destinationFolder.CopyHere($zipPackageItems,0x10) 
+  $destinationFolder.CopyHere($zipPackageItems,0x14) 
 
   if ($packageName) {
     $packagelibPath=$env:chocolateyPackageFolder


### PR DESCRIPTION
...ess bar. My main purpose in doing this is for puppetized installations - I would not want this popping up on a developer machine when a new version is available as it would surprise them and they may unintentionally cancel the unzip and stop the chocolatey installation.

For CopyHere constants reference: http://technet.microsoft.com/en-us/library/ee176633.aspx 
