### PR TITLE
A string had multiplication being performed on it, causing an error.

### DIFF
--- a/src/functions/Get-LongPackageVersion.ps1
+++ b/src/functions/Get-LongPackageVersion.ps1
@@ -2,7 +2,7 @@ function Get-LongPackageVersion {
 param(
   [string] $packageVersion = ''
 )
-  $longVersion = $packageVersion.Split('-')[0].Split('.') | %{('0' * (8 - $_.Length)) + $_}
+  $longVersion = $packageVersion.Split('-')[0].Split('.') | %{(0 * (8 - $_.Length)) + $_}
   
   $longVersionReturn = [System.String]::Join('.',$longVersion)
   


### PR DESCRIPTION
When grabbing the package version, a string ( '0' ), was being multiplied, causing an error.
