### PR TITLE
[BUG] `chocolatey version all` prints only the last package's information

### DIFF
--- a/src/functions/Chocolatey-Version.ps1
+++ b/src/functions/Chocolatey-Version.ps1
@@ -18,6 +18,7 @@ param(
   
   Write-Debug "based on: `'$srcArgs`' feed"
   
+  $versionsObj = New-Object –typename PSObject
   foreach ($package in $packages) {
     $packageArgs = "list ""$package"" $srcArgs"
     if ($prerelease -eq $true) {


### PR DESCRIPTION
There was a scoping issue with $versionsObj.
