### PR TITLE
Get-WebFileSimple, to remove gow dependency from JavaJDK package

### DIFF
--- a/src/helpers/functions/Get-WebFileSimple.ps1
+++ b/src/helpers/functions/Get-WebFileSimple.ps1
@@ -1,0 +1,32 @@
+## Get-WebFile-Simple (aka wget for PowerShell)
+##############################################################################################################
+## Downloads a file or page from the web
+## History:
+##############################################################################################################
+function Get-WebFileSimple {
+param(
+  $url = '', #(Read-Host "The URL to download"),
+  $fileName = $null,
+  $cookies = '',
+  [switch]$ignoreInvalidCert
+)
+  Write-Host "Running 'Get-WebFile' for $fileName with url:`'$url`', cookies: `'$cookies`'";
+  
+  if($ignoreInvalidCert -eq $true)
+  {
+    $origCertCheck = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
+  }
+  
+  $webclient = new-object System.Net.WebClient
+  if($cookies -ne '')
+  {
+    $webclient.Headers.Add("Cookie",$cookies);
+  }
+  $webclient.DownloadFile($url, $fileName);
+  
+  if($ignoreInvalidCert -eq $true)
+  {
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $origCertCheck
+  }
+}


### PR DESCRIPTION
- uses WebClient.DownloadFile to download files
- allows adding cookies.  (necessary for some sites, i.e. downloading java jdk from oracle)
- allows ignoring invalid certificates (self-signed, etc)

I would like to use the existing JavaJDK package, but can't because it depends on gow, which conflicts with other *nix tools I'm using.  He only needs gow for wget.  With this function, I'm able to download the file without wget.
