### PR TITLE
Globalized CPU bit-width function for easy access in packages

### DIFF
--- a/src/helpers/chocolateyInstaller.psm1
+++ b/src/helpers/chocolateyInstaller.psm1
@@ -9,4 +9,24 @@ Resolve-Path $helpersPath\functions\*.ps1 |
     ? { -not ($_.ProviderPath.Contains(".Tests.")) } |
     % { . $_.ProviderPath }
 
-Export-ModuleMember -Function Start-ChocolateyProcessAsAdmin, Install-ChocolateyPackage, Uninstall-ChocolateyPackage, Install-ChocolateyZipPackage, Install-ChocolateyPowershellCommand, Get-ChocolateyWebFile, Install-ChocolateyInstallPackage, Get-ChocolateyUnzip, Write-ChocolateySuccess, Write-ChocolateyFailure, Install-ChocolateyPath, Install-ChocolateyDesktopLink, Install-ChocolateyPinnedTaskBarItem, Install-ChocolateyExplorerMenuItem, Install-ChocolateyFileAssociation, Install-ChocolateyEnvironmentVariable, Write-Host, Write-Debug, Write-Error, Update-SessionEnvironment, Install-ChocolateyVsixPackage
+Export-ModuleMember -Function `
+	Get-ChocolateyWebFile,`
+	Get-ChocolateyUnzip,`
+	Get-ProcessorBits,`
+	Install-ChocolateyInstallPackage,`
+	Install-ChocolateyPackage,`
+	Install-ChocolateyZipPackage,`
+	Install-ChocolateyPowershellCommand,`
+	Install-ChocolateyPath,`
+	Install-ChocolateyDesktopLink,`
+	Install-ChocolateyPinnedTaskBarItem,`
+	Install-ChocolateyExplorerMenuItem,`
+	Install-ChocolateyFileAssociation,`
+	Install-ChocolateyEnvironmentVariable,`
+	Install-ChocolateyVsixPackage,`
+	Write-ChocolateySuccess,`
+	Write-ChocolateyFailure,`
+	Write-Host,`Write-Debug,`Write-Error,`
+	Start-ChocolateyProcessAsAdmin,`
+	Uninstall-ChocolateyPackage,`
+	Update-SessionEnvironment

--- a/src/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -37,26 +37,23 @@ param(
   [string] $url64bit = $url
 )
   Write-Debug "Running 'Get-ChocolateyWebFile' for $packageName with url:`'$url`', fileFullPath:`'$fileFullPath`',and url64bit:`'$url64bit`'";
-  
   $url32bit = $url;
-  $processor = Get-WmiObject Win32_Processor
-  $procCount=(Get-WmiObject Win32_ComputerSystem).NumberofProcessors
-  if ($procCount -eq '1') {
-     $is64bit = $processor.AddressWidth -eq 64
-     Write-Debug "Processor width is $($processor.AddressWidth)."
-	 } else {
-	 Write-Debug "First processor width is $($processor[0].AddressWidth)."
-	 $is64bit = $processor[0].AddressWidth -eq 64
-	 }
-  $systemBit = '32 bit'
-  if ($is64bit) {
-    $systemBit = '64 bit';
-    $url = $url64bit;
+  
+  if (Get-ProcessorBits 64) {
+	$bitWidth = 64
+	$url = $url64bit;
+  } else { # I am just assuming that it's either 32 or 64. 
+	$bitWidth = 32
+  }
+  Write-Debug "CPU is $bitWidth bit"
+  
+  if ($url32bit -eq $url64bit) {
+	$bitPackage = 32
+  } else {
+	$bitPackage = $bitWidth
   }
   
-  $downloadMessage = "Downloading $packageName ($url) to $fileFullPath"
-  if ($url32bit -ne $url64bit) {$downloadMessage = "Downloading $packageName $systemBit ($url) to $fileFullPath.";}
-  Write-Host "$downloadMessage"
+  Write-Host "Downloading $packageName $bitWidth bit ($url) to $fileFullPath"
   #$downloader = new-object System.Net.WebClient
   #$downloader.DownloadFile($url, $fileFullPath)
   if ($url.StartsWith('http')) {

--- a/src/helpers/functions/Get-ProcessorBits.ps1
+++ b/src/helpers/functions/Get-ProcessorBits.ps1
@@ -1,0 +1,40 @@
+﻿function Get-ProcessorBits {
+<#
+.SYNOPSIS
+Get the system architecture address width.
+
+.DESCRIPTION
+This will return the system architecture address width (probably 32 or 64 bit).
+
+.PARAMETER compare
+This optional parameter causes the function to return $True or $False, depending on wether or not the bitwidth matches.
+
+.NOTES
+When your installation script has to know what architecture it is run on, this simple function comes in handy.
+#>
+param(
+	$compare # You can optionally pass a value to compare the system architecture and receive $True or $False in stead of 32|64|nn
+)
+	Write-Debug "Running 'System-GetBits'"
+	
+	#TODO: This is trivial at the moment, but Get-WmiObject Win32_Processor IS SLOW.
+	#      Can we cache this?
+	
+	# Get the address width
+    $proc = Get-WmiObject Win32_Processor
+    $procCount = (Get-WmiObject Win32_ComputerSystem).NumberofProcessors
+    if ($procCount -eq '1') {
+        $bits = $proc.AddressWidth
+    } else {
+        $bits = $proc[0].AddressWidth
+    }
+	
+	# Return bool|int
+	if ("$compare" -ne '' -and $compare -eq $bits) {
+		return $True
+	} elseif ("$compare" -ne '') {
+		return $False
+	} else {
+		return $bits
+	}
+}


### PR DESCRIPTION
I had to export the module in `\src\helpers\chocolateyInstaller.psm1`  anyway, so I improved readability while I was at it.
