### PR TITLE
Issue 235 - Created new Helper Function to create generic shortcut

### DIFF
--- a/src/helpers/functions/Install-ChocolateyShortcut.ps1
+++ b/src/helpers/functions/Install-ChocolateyShortcut.ps1
@@ -1,0 +1,105 @@
+﻿function Install-ChocolateyShortcut {
+<#
+.SYNOPSIS
+This adds a shortcut, at the specified location, with the option to specify 
+a number of additional properties for the shortcut, such as Working Directory,
+Arguments, Icon Location, and Description.
+
+.PARAMETER ShortcutFilePath
+The full absolute path to where the shortcut should be created.  This is mandatory.
+
+.PARAMETER TargetPath
+The full absolute path to the target for new shortcut.  This is mandatory.
+
+.PARAMETER WorkingDirectory
+The full absolute path of the Working Directory that will be used by 
+the new shortcut.  This is optional
+
+.PARAMETER Arguments
+Additonal arguments that should be passed along to the new shortcut.  This 
+is optional.
+
+.PARAMETER IconLocation
+The full absolute path to an icon file to be used for the new shortcut.  This
+is optional.
+
+.PARAMETER Description
+A text description to be associated with the new description.  This is optional.
+
+.EXAMPLE
+Install-ChocolateyShortcut -shortcutFilePath "C:\test.lnk" -targetPath "C:\test.exe"
+
+This will create a new shortcut at the location of "C:\test.lnk" and link to the file
+located at "C:\text.exe"
+
+.EXAMPLE
+Install-ChocolateyShortcut -shortcutFilePath "C:\notepad.lnk" -targetPath "C:\Windows\System32\notepad.exe" -workDirectory "C:\" -arguments "C:\test.txt" -iconLocation "C:\test.ico" -description "This is the description"
+
+This will create a new shortcut at the location of "C:\notepad.lnk" and link to the
+Notepad application.  In addition, other properties are being set to specify the working 
+directoy, an icon to be used for the shortcut, along with a description and arguments.
+
+#>
+	param(
+	  [string] $shortcutFilePath,
+	  [string] $targetPath,
+	  [string] $workingDirectory,
+	  [string] $arguments,
+	  [string] $iconLocation,
+	  [string] $description
+	)
+
+	Write-Debug "Running 'Install-ChocolateyShortcut' with parameters ShortcutFilePath: `'$shortcutFilePath`', TargetPath: `'$targetPath`', WorkingDirectory: `'$workingDirectory`', Arguments: `'$arguments`', IconLocation: `'$iconLocation`', Description: `'$description`'";
+
+	if(!$shortcutFilePath) {
+		Write-ChocolateyFailure "Install-ChocolateyShortcut" "Missing ShortCutFilePath input parameter."
+		return
+	}
+	
+	if(!$targetPath) {
+		Write-ChocolateyFailure "Install-ChocolateyShortcut" "Missing TargetPath input parameter."
+		return
+	}
+	
+	if(!(Test-Path($targetPath))) {
+		Write-ChocolateyFailure "Install-ChocolateyShortcut" "TargetPath does not exist, so can't create shortcut."
+		return
+	}
+	
+	if($iconLocation) {
+		if(!(Test-Path($iconLocation))) {
+			Write-ChocolateyFailure "Install-ChocolateyShortcut" "IconLocation does not exist, so can't create shortcut."
+			return
+		}
+	}
+	
+	if($workingDirectory) {
+		if(!(Test-Path($workingDirectory))) {
+			Write-ChocolateyFailure "Install-ChocolateyShortcut" "WorkingDirectory does not exist, so can't create shortcut."
+			return
+		}
+	}
+	
+	Write-Debug "Creating Shortcut..."
+	
+	try {
+		$global:WshShell = New-Object -com "WScript.Shell"
+	    $lnk = $global:WshShell.CreateShortcut($shortcutFilePath)
+	    $lnk.TargetPath = $targetPath
+		$lnk.WorkingDirectory = $workingDirectory
+	    $lnk.Arguments = $arguments
+	    if($iconLocation) {
+	        $lnk.IconLocation = $iconLocation
+	    }
+	    $lnk.Description = $description
+	    $lnk.Save()
+		
+		Write-Debug "Shortcut created."
+
+		Write-ChocolateySuccess "Install-ChocolateyShortcut completed"
+		
+	}
+	catch {
+		Write-ChocolateyFailure "Install-ChocolateyShortcut" "There were errors attempting to create shortcut. The error message was '$_'."
+	}
+}

--- a/tests/unit/Install-ChocolateyShortcut.Tests.ps1
+++ b/tests/unit/Install-ChocolateyShortcut.Tests.ps1
@@ -1,0 +1,113 @@
+﻿$here = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$common = Join-Path (Split-Path -Parent $here)  '_Common.ps1'
+$base = Split-Path -parent (Split-Path -Parent $here)
+. $common
+. "$base\src\helpers\functions\Install-ChocolateyShortcut.ps1"
+
+Describe "Install-ChocolateyShortcut" {
+	Context "When no ShortCutFilePath parameter is passed to this function" {
+		Mock Write-ChocolateyFailure
+		
+		Install-ChocolateyShortcut -targetPath "TestTargetPath" -workingDirectory "TestWorkingDiectory" -arguments "TestArguments" -iconLocation "TestIconLocation" -description "TestDescription"
+	
+		It "should return an error" {
+			Assert-MockCalled Write-ChocolateyFailure -parameterFilter {$failureMessage -eq "Missing ShortCutFilePath input parameter."}
+		}
+	}
+	
+	Context "When no TargetPath parameter is passed to this function" {
+		Mock Write-ChocolateyFailure
+		
+		Install-ChocolateyShortcut -shortcutFilePath "TestShortcutFilePath" -workingDirectory "TestWorkingDiectory" -arguments "TestArguments" -iconLocation "TestIconLocation" -description "TestDescription"
+		
+		It "should return an error" {
+			Assert-MockCalled Write-ChocolateyFailure -parameterFilter {$failureMessage -eq "Missing TargetPath input parameter."}
+		}
+	}
+	
+	Context "When TargetPath is a location that does not exist" {
+		Mock Write-ChocolateyFailure
+		
+		Install-ChocolateyShortcut -targetPath "C:\TestTargetPath.txt" -shortcutFilePath "TestShortcutFilePath"
+		
+		It "should return an error" {
+			Assert-MockCalled Write-ChocolateyFailure -parameterFilter {$failureMessage -eq "TargetPath does not exist, so can't create shortcut."}
+		}
+	}
+	
+	Context "When a Working Directory is provided, and this parth doesn't exist" {
+		Mock Write-ChocolateyFailure
+		
+		Install-ChocolateyShortcut -shortcutFilePath "TestShortcutFilePath" -targetPath "C:\Chocolatey\chocolateyinstall\LICENSE.txt" -workingDirectory "C:\TestWorkingDiectory" -arguments "TestArguments" -description "TestDescription"
+		
+		It "should return an error" {
+			Assert-MockCalled Write-ChocolateyFailure -parameterFilter {$failureMessage -eq "WorkingDirectory does not exist, so can't create shortcut."}
+		}
+	}
+	
+	Context "When an IconLocation is provided, and the path doesn't exist" {
+		Mock Write-ChocolateyFailure
+		
+		Install-ChocolateyShortcut -shortcutFilePath "TestShortcutFilePath" -targetPath "C:\Chocolatey\chocolateyinstall\LICENSE.txt" -arguments "TestArguments" -iconLocation "c:\iconlocation.ico" -description "TestDescription"
+		
+		It "should return an error" {
+			Assert-MockCalled Write-ChocolateyFailure -parameterFilter {$failureMessage -eq "IconLocation does not exist, so can't create shortcut."}
+		}
+    }
+
+    Context "When valid shortcutpath and targetpath are provided" {
+        $shortcutPath = "c:\test.lnk"
+        $targetPath="C:\test.txt"
+
+        Set-Content $targetPath -value "my test text."
+
+		Install-ChocolateyShortcut -shortcutFilePath $shortcutPath -targetPath $targetPath
+
+        $result = Test-Path($shortcutPath)
+
+		It "should succeed." {
+			$result | should Be $true
+		}
+
+        # Tidy up items that were created as part of this test
+        if(Test-Path($shortcutPath)) {
+            Remove-Item $shortcutPath
+        }
+
+        if(Test-Path($targetPath)) {
+            Remove-Item $targetPath
+        }
+	}
+	
+	Context "When all parameters are passed with valid values" {
+		$shortcutPath = "c:\test.lnk"
+        $targetPath = "C:\test.txt"
+		$workingDirectory = "C:\"
+		$arguments = "args"
+		$iconLocation = "C:\test.ico"
+		$description = "Description"
+
+        Set-Content $targetPath -value "my test text."
+		Set-Content $iconLocation -Value "icon"
+
+		Install-ChocolateyShortcut -shortcutFilePath $shortcutPath -targetPath $targetPath -workDirectory $workingDirectory -arguments $arguments -iconLocation $iconLocation -description $description
+
+        $result = Test-Path($shortcutPath)
+		
+		It "should succeed." {
+		}
+		
+        # Tidy up items that were created as part of this test
+        if(Test-Path($shortcutPath)) {
+            Remove-Item $shortcutPath
+        }
+
+        if(Test-Path($targetPath)) {
+            Remove-Item $targetPath
+        }		
+		
+		if(Test-Path($iconLocation)) {
+			Remove-Item $iconLocation
+		}
+	}
+}


### PR DESCRIPTION
As described here:

https://github.com/chocolatey/chocolatey/issues/235

I have created a generic Install-ChocoatelyShortcut helper function to allow a shortcut, with optional parameters, to be created anywhere the user specifies.

I believe that this may also solve Issue 218 as well:

https://github.com/chocolatey/chocolatey/issues/218

I have included 7 new Unit Tests to verify the functionality.

The only thing that I am not "convinced" by are the last two tests.  I have created fake files at the root of the C:\ drive, which are tided up after the test is completed.  Obviously, it would be better to mock these files.  I attempted to use TestDrive for this purpose, however, I could not get this to work.  I believe that this is due to .CreateShortcut being a call into a ComObject, which TestDrive can't handle.

Let me know if you have any questions.

Thanks

Gary
