### PR TITLE
Minor typo fix in uninstall script: "uninINstalling"

### DIFF
--- a/src/functions/Chocolatey-Uninstall.ps1
+++ b/src/functions/Chocolatey-Uninstall.ps1
@@ -12,7 +12,7 @@ param(
     return
   }
 
-    Write-Host "Chocolatey (v$chocVer) is unininstalling $packageName..." -ForegroundColor $RunNote -BackgroundColor Black
+    Write-Host "Chocolatey (v$chocVer) is uninstalling $packageName..." -ForegroundColor $RunNote -BackgroundColor Black
   
 	
 	$packages = $packageName


### PR DESCRIPTION
C:\Users\me>cuninst vim
Chocolatey (v0.9.8.20) is unininstalling vim...
