### PR TITLE
Handle failures when running NuGet (exitCode != 0, output to stderr)

### DIFF
--- a/src/functions/Run-NuGet.ps1
+++ b/src/functions/Run-NuGet.ps1
@@ -45,7 +45,12 @@ param(
     Write-Host $errors -BackgroundColor Red -ForegroundColor White
     #Throw $errors
   }
-  
+
+  if (($errors -ne '') -or ($process.ExitCode -ne 0)) {
+    $error = ("Execution failed for command: `"{0}`" {1}" -f $nugetExe, $packageArgs)
+    throw $error
+  }
+
   if (($nugetOutput -eq '' -or $nugetOutput -eq $null) -and ($errors -eq '' -or $errors -eq $null)) {
     $noExecution = 'Execution of NuGet not detected. Please make sure you have .NET Framework 4.0 installed and are passing arguments to the install command.'
     #write-host  -BackgroundColor Red -ForegroundColor White


### PR DESCRIPTION
Previously the script Run-NuGet.ps1 ignored the process exit code so that errors were not propagated to the caller.

This change throws an error when either the process exits with a non-zero value or if errors are written to stderr, which makes Chocolatey more suitable for being called from other scripts.

For example, I'm using Chocolatey to install and build a Linux virtual machine on Windows with a single PowerShell command (https://github.com/webcoyote/linux-vm). Chocolatey is awesome for projects like this!
