### PR TITLE
Fix bash arg quoting, remove bash/batch shortcuts on uninstall

### DIFF
--- a/src/functions/Chocolatey-Uninstall.ps1
+++ b/src/functions/Chocolatey-Uninstall.ps1
@@ -24,6 +24,8 @@ param(
 		else {
 		  Write-Debug "Looking for $($package).$($versions.found)"
           $packageFolder = Join-Path $nugetLibPath "$($package).$($versions.found)" 
+          Write-host "Uninstalling from folder $packageFolder"
+          Get-ChocolateyBins $packageFolder -uninstall
           Run-ChocolateyPS1 $packageFolder $package "uninstall"
 		  Remove-Item -Recurse -Force $packageFolder
 		}

--- a/src/functions/Generate-BinFile.ps1
+++ b/src/functions/Generate-BinFile.ps1
@@ -11,6 +11,7 @@ param(
   $path = $path.ToLower().Replace($nugetPath.ToLower(), "%DIR%..\").Replace("\\","\")
   $pathBash = $path.Replace("%DIR%..\","`$DIR/../").Replace("\","/")
   Write-Host "Adding $packageBatchFileName and pointing to `'$path`'." -ForegroundColor $Note
+  Write-Host "Adding $packageBashFileName and pointing to `'$path`'." -ForegroundColor $Note
   if ($useStart) {
     Write-Host "Setting up $name as a non-command line application."  -ForegroundColor $Note
 "@echo off

--- a/src/functions/Generate-BinFile.ps1
+++ b/src/functions/Generate-BinFile.ps1
@@ -20,7 +20,7 @@ start """" ""$path"" %*" | Out-File $packageBatchFileName -encoding ASCII
 
 "#!/bin/sh
 DIR=`${0%/*}
-""$pathBash"" `$* &" | Out-File $packageBashFileName -encoding ASCII 
+""$pathBash"" ""`$*"" &" | Out-File $packageBashFileName -encoding ASCII
  
   } else {
 "@echo off
@@ -29,6 +29,6 @@ SET DIR=%~dp0%
   
 "#!/bin/sh
 DIR=`${0%/*}
-""$pathBash"" `$*" | Out-File $packageBashFileName -encoding ASCII 
+""$pathBash"" ""`$*""" | Out-File $packageBashFileName -encoding ASCII
   }
 }

--- a/src/functions/Get-ChocolateyBins.ps1
+++ b/src/functions/Get-ChocolateyBins.ps1
@@ -1,6 +1,7 @@
 function Get-ChocolateyBins {
 param(
-  [string] $packageFolder
+  [string] $packageFolder,
+  [switch] $uninstall
 )
   Write-Debug "Running 'Get-ChocolateyBins' for $packageFolder";
 
@@ -17,9 +18,17 @@ Adding batch files for any executables found to a location on PATH. In other wor
       foreach ($file in $files) {
         if (!(test-path($file.FullName + '.ignore'))) {
           if (test-path($file.FullName + '.gui')) {
-            Generate-BinFile $file.Name.Replace(".exe","").Replace(".EXE","") $file.FullName -useStart
+            if ($uninstall) {
+              Remove-BinFile $file.Name.Replace(".exe","").Replace(".EXE","") $file.FullName
+            } else {
+              Generate-BinFile $file.Name.Replace(".exe","").Replace(".EXE","") $file.FullName -useStart
+            }
           } else {
-            Generate-BinFile $file.Name.Replace(".exe","").Replace(".EXE","") $file.FullName
+            if ($uninstall) {
+              Remove-BinFile $file.Name.Replace(".exe","").Replace(".EXE","") $file.FullName
+            } else {
+              Generate-BinFile $file.Name.Replace(".exe","").Replace(".EXE","") $file.FullName
+            }
           }
           $batchCreated = $true
         }

--- a/src/functions/Remove-BinFile.ps1
+++ b/src/functions/Remove-BinFile.ps1
@@ -1,0 +1,27 @@
+function Remove-BinFile {
+param(
+  [string] $name, 
+  [string] $path
+)
+  Write-Debug "Running 'Remove-BinFile' for $name with path:`'$path`'";
+
+  $packageBatchFileName = Join-Path $nugetExePath "$name.bat"
+  $packageBashFileName = Join-Path $nugetExePath "$name"
+  $path = $path.ToLower().Replace($nugetPath.ToLower(), "%DIR%..\").Replace("\\","\")
+  $pathBash = $path.Replace("%DIR%..\","`$DIR/../").Replace("\","/")
+  Write-Debug "Attempting to remove the batch and bash shortcuts: $packageBatchFileName and $packageBashFileName"
+  if (Test-Path $packageBatchFileName) {
+    Write-Host "Removing batch file $packageBatchFileName which pointed to `'$path`'." -ForegroundColor $Note
+    Remove-Item $packageBatchFileName
+  }
+  else {
+    Write-Host "Tried to remove batch file $packageBatchFileName but it was already removed." -ForegroundColor $Note
+  }
+  if (Test-Path $packageBashFileName) {
+    Write-Host "Removing bash file $packageBashFileName which pointed to `'$path`'." -ForegroundColor $Note
+    Remove-Item $packageBashFileName
+  }
+  else {
+    Write-Host "Tried to remove bash file $packageBashFileName but it was already removed." -ForegroundColor $Note
+  }
+}


### PR DESCRIPTION
Put quotes around the args passed to the bash shell script (without quotes spaces in the args will not work)

When a Chocolatey-Uninstall is done, the bash and batch shortcuts will now be removed using Remove-BinFile

I've also added a message in Generate-BinFile that the bash shortcut is getting added, as this was missing.

I've also added a message to Chocolatey-Uninstall describing which directory is removed on uninstall.
