### PR TITLE
chocolatey version all version for a specific package added

### DIFF
--- a/src/chocolatey.ps1
+++ b/src/chocolatey.ps1
@@ -81,7 +81,7 @@ switch -wildcard ($command)
   "uninstall" {Chocolatey-Uninstall $packageName $version $installArguments; }
   "search" { Chocolatey-List $packageName $source; }
   "list" { Chocolatey-List $packageName $source; }
-  "version" { Chocolatey-Version $packageName $source; }
+  "version" { Chocolatey-Version $packageName $version $source; }
   "webpi" { Chocolatey-WebPI $packageName $installArguments; }
   "windowsfeatures" { Chocolatey-WindowsFeatures $packageName; }
   "cygwin" { Chocolatey-Cygwin $packageName $installArguments; }

--- a/src/functions/Chocolatey-Version.ps1
+++ b/src/functions/Chocolatey-Version.ps1
@@ -1,6 +1,7 @@
 ﻿function Chocolatey-Version {
 param(
   [string] $packageName='',
+  [string] $version='',
   [string] $source=''
 )
 
@@ -11,7 +12,13 @@ param(
   if ($packageName -eq 'all') {
     Write-Debug "Reading all packages in $nugetLibPath"
     $packageFolders = Get-ChildItem $nugetLibPath | sort name
-    $packages = $packageFolders -replace "(\.\d.*)+"|gu 
+    $packages = $packageFolders -replace "(\.\d.*)+"|gu
+
+  }
+
+  if ($version -eq 'all') {
+    $packageFolders=Get-PackageFoldersForPackage $packageName
+    $packageversions=$packageFolders -replace "$packageName\."
   }
   
   $srcArgs = Get-SourceArguments $source
@@ -32,7 +39,14 @@ param(
     
     if ($packageName -ne 'chocolatey') {
       $versionFound = 'no version'
-      $packageFolderVersion = Get-LatestPackageVersion(Get-PackageFolderVersions($package))
+      
+      if ($version -eq 'all') {
+      $packagefolderversion = $packageversions
+      }
+      else {
+        $packageFolderVersion = Get-LatestPackageVersion(Get-PackageFolderVersions($package))
+      }
+
 
       if ($packageFolderVersion -notlike '') { 
         #Write-Host $packageFolder
@@ -71,15 +85,19 @@ param(
           $verMessage = "$package does not appear to be on the source(s) specified: "
       }
       
-      $versions = @{name=$package; latest = $versionLatest; found = $versionFound; latestCompare = $versionLatestCompare; foundCompare = $versionFoundCompare; verMessage = $verMessage}
-      $versionsObj = New-Object –typename PSObject -Property $versions
-      $versionsObj
+      foreach ($versions in $versionfound) {
+        $versions = @{name=$package; latest = $versionLatest; found = $versions; latestCompare = $versionLatestCompare; foundCompare = $versionFoundCompare; verMessage = $verMessage}
+        $versionsObj = New-Object –typename PSObject -Property $versions
+        $versionsObj
+      }
     }
     
     else {
-      $versions = @{name=$package; found = $versionFound}
-      $versionsObj = New-Object –typename PSObject -Property $versions
-      $versionsObj
+      foreach ($versions in $versionfound) {
+        $versions = @{name=$package; found = $versions}
+        $versionsObj = New-Object –typename PSObject -Property $versions
+        $versionsObj
+      }
     }
   }
 }


### PR DESCRIPTION
usage: .\chocolatey.ps1 version sysinternals -version all -lo

we might need to do a compare-object allinstalled current to get
a list of 'old' packages to not cleanup if using cup.  Currently
cup doesnt do any cleanup and orphans packages in lib
