### PR TITLE
Proposed Fix for Issue #265 - Correcting problem when no parameters passed into Chocolatey-Uninstall

### DIFF
--- a/src/functions/Chocolatey-Uninstall.ps1
+++ b/src/functions/Chocolatey-Uninstall.ps1
@@ -6,12 +6,17 @@ param(
 )
   Write-Debug "Running 'Chocolatey-Uninstall' for $packageName with version:`'$version`', installerArguments: `'$installerArguments`'";
 
+  if(!$packageName) {
+	Write-ChocolateyFailure "Chocolatey-Uninstall" "Missing PackageName input parameter."
+	return
+  }
+  
   if ($packageName -eq 'all') { 
     write-host "Uninstalling all packages is not yet supported in this version. "  
 	# by default this should prompt user 2x.  Also can provide a -nuke switch for prompt bypass
     return
   }
-
+  
     Write-Host "Chocolatey (v$chocVer) is unininstalling $packageName..." -ForegroundColor $RunNote -BackgroundColor Black
   
 	

--- a/tests/unit/Chocolatey-Uninstall.tests.ps1
+++ b/tests/unit/Chocolatey-Uninstall.tests.ps1
@@ -1,0 +1,15 @@
+﻿$here = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$common = Join-Path (Split-Path -Parent $here)  '_Common.ps1'
+. $common
+
+Describe "Chocolatey-Uninstall" {
+  Context "When no PackageName parameter is passed to this function" {
+    Mock Write-ChocolateyFailure
+    
+    Chocolatey-Uninstall
+  
+    It "should return an error" {
+      Assert-MockCalled Write-ChocolateyFailure -parameterFilter {$failureMessage -eq "Missing PackageName input parameter."}
+    }
+  }
+}


### PR DESCRIPTION
In an attempt to help out, I have had a stab at fixing the reported issue #265 regarding calling Chocolatey-Uninstall with no parameters.  I have added what I "think" is the necessary code, along with a test which proves that at least it does what I think it does.  Let me know if you have any questions.  Not sure if this captures all the requirements, for instance, the need for displaying the help documentation, instead, it raised an error.  Would be interested to hear your thoughts on whether this is applicable or not, or what could be done better.  Thanks
