### PR TITLE
WIP - help refactor

### DIFF
--- a/src/functions/Chocolatey-Help.ps1
+++ b/src/functions/Chocolatey-Help.ps1
@@ -30,34 +30,65 @@ If you do not accept the license of a package you are installing, please uninsta
 $h2
 Waiver of Responsibility
 $h2
-The use of chocolatey means that an individual using chocolatey assumes the responsibility for any changes (including any damages of any sort) that occur to the system as a result of using chocolatey. 
-This does not supercede the verbage or enforcement of the license for chocolatey (currently Apache 2.0), it is only noted here that you are waiving any rights to collect damages by your use of chocolatey. 
-It is recommended you read the license (http://www.apache.org/licenses/LICENSE-2.0) to gain a full understanding (especially section 8. Limitation of Liability) prior to using chocolatey. 
+The use of chocolatey means that an individual using chocolatey assumes the responsibility for any changes (including any damages of any sort) that occur to the system as a result of using chocolatey.
+This does not supercede the verbage or enforcement of the license for chocolatey (currently Apache 2.0), it is only noted here that you are waiving any rights to collect damages by your use of chocolatey.
+It is recommended you read the license (http://www.apache.org/licenses/LICENSE-2.0) to gain a full understanding (especially section 8. Limitation of Liability) prior to using chocolatey.
 $h2
 }
 $h2
 $h2
 Usage
 $h2
-chocolatey [install [packageName [-source source] [-version version] | pathToPackagesConfig]  | installmissing packageName [-source source] | update packageName [-source source] [-version version] | list [packageName] [-source source] | help | version [packageName] | webpi packageName | windowsfeatures packageName | gem packageName [-version version] |uninstall packageName]
 
-example: chocolatey install nunit
-example: chocolatey install nunit -version 2.5.7.10213
-example: chocolatey install packages.config
-example: chocolatey installmissing nunit
-example: chocolatey update nunit -source http://somelocalfeed.com/nuget/
-example: chocolatey help
-example: chocolatey list (might take awhile)
-example: chocolatey list nunit
-example: chocolatey version
-example: chocolatey version nunit
-example: chocolatey uninstall
+chocolatey command [options]
 
-A shortcut to 'chocolatey install' is 'cinst'
-cinst [packageName  [-source source] [-version version] | pathToPackagesConfig]
-example: cinst 7zip
-example: cinst ruby -version 1.8.7
-example: cinst packages.config
+commands:
+install
+installmissing
+update
+uninstall
+search
+list
+version
+webpi
+windowsfeatures
+cygwin
+python
+gem
+pack
+push
+help
+sources
+
+$h1
+For more detailed help, use: 'chocolatey [command] help'
+example: chocolatey list help
 $h1
 "@ | Write-Host
 }
+# chocolatey [install [packageName [-source source] [-version version] | pathToPackagesConfig]  | installmissing packageName [-source source] | update packageName [-source source] [-version version] | list [packageName] [-source source] | help | version [packageName] | webpi packageName | windowsfeatures packageName | gem packageName [-version version] | uninstall [packageName] | sources [list] | [add name source] | [remove name] | [enable name] | [disable name]
+
+# missing usage above:
+# uninstall, search, cygwin, python, pack, push
+
+# missing examples below:
+# search, webpi, windowsfeatures, cygwin, python, gem, pack, push
+
+# example: chocolatey install nunit
+# example: chocolatey install nunit -version 2.5.7.10213
+# example: chocolatey install packages.config
+# example: chocolatey installmissing nunit
+# example: chocolatey update nunit -source http://somelocalfeed.com/nuget/
+# example: chocolatey help
+# example: chocolatey list (might take awhile)
+# example: chocolatey list nunit
+# example: chocolatey version
+# example: chocolatey version nunit
+# example: chocolatey uninstall
+# example: chocolatey sources add local http://somelocalfeed.com/nuget/
+
+# A shortcut to 'chocolatey install' is 'cinst'
+# cinst [packageName  [-source source] [-version version] | pathToPackagesConfig]
+# example: cinst 7zip
+# example: cinst ruby -version 1.8.7
+# example: cinst packages.config

--- a/src/functions/Chocolatey-Install.ps1
+++ b/src/functions/Chocolatey-Install.ps1
@@ -1,10 +1,65 @@
 ﻿function Chocolatey-Install {
 param(
-  [string] $packageName, 
-  [string] $source = '', 
+  [string] $packageName,
+  [string] $source = '',
   [string] $version = '',
   [string] $installerArguments = ''
 )
+  if($packageName -eq 'help'){
+@"
+$h1
+Help for chocolatey install command
+$h1
+$h2
+Usage
+$h2
+
+chocolatey [install [packageName [-source source] [-version version] | pathToPackagesConfig]
+
+$h2
+More Information
+$h2
+
+In addition to specifying custom nuget sources, you may also specify that you would like to install your component via the package manager of any of the following:
+* webpi
+* windowsfeatures
+* cygwin
+* python
+* ruby
+
+You can also operate against these alternate sources as follows:
+
+chocolatey python packageName
+
+or use the shortcut: cpython
+
+Use chocolatey help python for more information
+
+$h2
+Examples
+$h2
+
+chocolatey install nunit
+chocolatey install nunit -version 2.5.7.10213
+chocolatey install packages.config
+chocolatey install bash -source cygwin
+
+$h2
+Shorcut
+$h2
+
+cinst [arguments]
+
+"@ | Write-Host
+    Write-Host 'Enter H to go to online help, or any other key to quit'
+    $x = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+
+    if($x.Character -eq 'h')
+    {
+      Invoke-Expression “cmd.exe /C start https://github.com/chocolatey/chocolatey/wiki/CommandsInstall”
+    }
+    return
+  }
   Write-Debug "Running 'Chocolatey-Install' for $packageName with source: `'$source`', version: `'$version`', installerArguments:`'$installerArguments`'";
 
   if($($packageName).EndsWith('.config')) {
@@ -12,8 +67,8 @@ param(
     Chocolatey-PackagesConfig $packageName
     return
   }
-  
-  switch -wildcard ($source) 
+
+  switch -wildcard ($source)
   {
     "webpi" { Chocolatey-WebPI $packageName $installerArguments; }
     "windowsfeatures" { Chocolatey-WindowsFeatures $packageName; }


### PR DESCRIPTION
Made `chocolatey help` much slimmer, and basically pointed to `chocolatey [command] help`. Implemented `chocolatey install help` to see if this approach will be satisfactory.

Also...yeah...it's still messy w/ comments and junk. I'll clean that up.

Ref https://github.com/chocolatey/chocolatey/issues/281
