### PR TITLE
Added batch mode to chocolatey.cmd - cinst multiple packages

### DIFF
--- a/src/chocolatey.cmd
+++ b/src/chocolatey.cmd
@@ -1,9 +1,9 @@
 @echo off
 
-SET DIR=%~dp0%
+set DIR=%~dp0%
 
 REM Handle empty parameter here because in the loop empty means 'end loop goto eof'
-if '%1'=='' GOTO usage
+if '%1'=='' goto usage
 
 REM Help
 if '%1'=='/?' goto usage
@@ -13,20 +13,44 @@ if '%1'=='/help' goto usage
 if '%1'=='help' goto usage
 if '%1'=='--help' goto usage
 
+REM Are we not installing (a) package(s)?
+if /i not '%1' == 'install' goto single
 
+REM are we not specifying a 3rd parameter?
+if '%3' == '' goto single
+
+REM If "-wildcard" is given as third parameter, we are installing a single package.
+set param=%3
+set param=%param:~0,1%
+if '%param%' == '-' goto single
+
+REM If we got no more than 2 parameters, we are installing a single package.
 set numArgs=0
-for %%n in (%*) do Set /A numArgs+=1
-if '%numArgs%' GTR '2' echo Installing packages in batch mode.
+for %%n in (%*) do set /A numArgs+=1
+if '%numArgs%' LEQ '2' goto single
 
-FOR %%P IN (%*) DO (
+REM Batch install
+echo Installing packages in batch mode.
+for %%P in (%*) do (
 	REM Installer
 	if not '%%P' == 'install' (
-		if '%numArgs%' GTR '2' echo Installing %%P ...
+		echo.
+		echo Installing %%P ...
+		echo.
 		@PowerShell -NoProfile -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%DIR%chocolatey.ps1' install %%P"
 	)
 )
+echo.
+echo Installed all packages. :)
+REM Except for the ones that failed. Need batch-logging. But we need normal logging first. It's in the pipeline @ #154
+goto :eof
+
+:single
+REM Single command
+@PowerShell -NoProfile -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%DIR%chocolatey.ps1' %*"
 goto :eof
 
 :usage
 REM Display help
 @PowerShell -NoProfile -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%DIR%chocolatey.ps1' help"
+goto :eof


### PR DESCRIPTION
I wrote this batch installer.

It's a small clever hack I wrote some time ago for myself. But now that I installed Chocolatey on a friend's computer, I realized how much I missed this invaluable feature, so I thought I'd put it in a pull request.

Everything remains the same, but you can now also do this:

``` cmd
cinst notepadplusplus 7zip vlc putty GoogleChrome firefox filezilla adobereader Skype Dropbox VirtualCloneDrive foobar2000 gimp pidgin xnview speccy opera xnview
```

..and go drink a cofffee. :)
