### PR TITLE
[Enhancement] Allow file uri to be used when getting packages

### DIFF
--- a/src/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -61,6 +61,7 @@ param(
   } elseif ($url.StartsWith('ftp')) {
     Get-FtpFile $url $fileFullPath
   } else {
+    if ($url.StartsWith('file:')) { $url = ([uri] $url).LocalPath }
     Write-Debug "We are attempting to copy the local item `'$url`' to `'$fileFullPath`'"
     Copy-Item $url -Destination $fileFullPath -Force
   }


### PR DESCRIPTION
Basically. this allows  Get-ChocolateyWebFile to handle file:/// URIs.
