### PR TITLE
First step in a cleaner output

### DIFF
--- a/src/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -59,7 +59,9 @@ param(
     $url = $url32bit
   }
 
-  Write-Host "Downloading $packageName $bitPackage bit ($url) to $fileFullPath"
+  Write-Host "Downloading $packageName $bitPackage bit"
+  Write-Host "From: $url"
+  Write-Host "To:   $fileFullPath"
   #$downloader = new-object System.Net.WebClient
   #$downloader.DownloadFile($url, $fileFullPath)
   if ($url.StartsWith('http')) {


### PR DESCRIPTION
The output looks a bit messy. 
This will make it clearer and easier to highlight (for debugging purposes).

Optional next step would be to keep the first line, and only show the other lines when the flag `-v` or `--verbose` is specified to Chocolatey.

See issue #374 @ https://github.com/chocolatey/chocolatey/issues/374
