### PR TITLE
Replace ascii cue to visual cue for "installing package"

### DIFF
--- a/src/functions/Chocolatey-NuGet.ps1
+++ b/src/functions/Chocolatey-NuGet.ps1
@@ -74,7 +74,7 @@ Write-Debug "Installing packages to `"$nugetLibPath`"."
             Remove-Item $packageFolder -force -recurse
           } else {
 
-            Write-Host "______ $installedPackageName v$installedPackageVersion ______" -ForegroundColor $RunNote -BackgroundColor Black
+            Write-Host "$installedPackageName v$installedPackageVersion" -ForegroundColor $Note -BackgroundColor Black
 
             if ([System.IO.Directory]::Exists($packageFolder)) {
               try {


### PR DESCRIPTION
Change old school ascii "underline" style cue to a visual cue by writing installing package title in brighter green.

This is especially convenient when you install 10 packages at once.

Just a proposition. Pending review.

See #374 @ https://github.com/chocolatey/chocolatey/issues/374
