### PR TITLE
Fix for multiple argument expansion under bash

### DIFF
--- a/src/functions/Generate-BinFile.ps1
+++ b/src/functions/Generate-BinFile.ps1
@@ -55,7 +55,7 @@ start """" ""$path"" %*" | Out-File $packageBatchFileName -encoding ASCII
 
 "#!/bin/sh
 DIR=`${0%/*}
-""$pathBash"" ""`$*"" &" | Out-File $packageBashFileName -encoding ASCII
+""$pathBash"" ""`$@"" &" | Out-File $packageBashFileName -encoding ASCII
 
     } else {
 
@@ -66,7 +66,7 @@ exit /b %ERRORLEVEL%" | Out-File $packageBatchFileName -encoding ASCII
 
 "#!/bin/sh
 DIR=`${0%/*}
-""$pathBash"" ""`$*""
+""$pathBash"" ""`$@""
 exit `$?" | Out-File $packageBashFileName -encoding ASCII
 
     }


### PR DESCRIPTION
Current implementation expands provided arguments and passes it as a single argument to the executable.
