### PR TITLE
Resolve issue with DISM "missing" or with the 32-bit DISM being called on a 64-bit system

### DIFF
--- a/src/functions/Chocolatey-WindowsFeatures.ps1
+++ b/src/functions/Chocolatey-WindowsFeatures.ps1
@@ -9,16 +9,24 @@ param(
   
   $chocoInstallLog = Join-Path $nugetChocolateyPath 'chocolateyWindowsFeaturesInstall.log';
   Append-Log $chocoInstallLog
+
+  # On a 64-bit OS, the 32-bit version of DISM can be called if the powershell host is 32-bit and results in an error...
+  # To fix this, we need to use a not-well know feature of 32-bit shells running on 64-bit OS, the "sysnative" directory.
+  if (Test-Path "$env:WinDir\sysnative\dism.exe") { 
+    $dism = "$env:WinDir\sysnative\dism.exe"
+  } else {
+    $dism = "$env:WinDir\System32\dism.exe"
+  }
   
   $checkStatement=@"
-`$dismInfo=(DISM /Online /Get-FeatureInfo /FeatureName:$packageName)
+`$dismInfo=(cmd /c `"$dism /Online /Get-FeatureInfo /FeatureName:$packageName`")
 if(`$dismInfo -contains 'State : Enabled') {return}
 if(`$dismInfo -contains 'State : Enable Pending') {return}
 "@
 
   $osVersion = (Get-WmiObject -class Win32_OperatingSystem).Version
  
-  $packageArgs = "/c DISM /Online /NoRestart /Enable-Feature"
+  $packageArgs = "/c $dism /Online /NoRestart /Enable-Feature"
   if($osVersion -ge 6.2) {
     $packageArgs += " /all"
   }

--- a/src/functions/Chocolatey-WindowsFeatures.ps1
+++ b/src/functions/Chocolatey-WindowsFeatures.ps1
@@ -33,7 +33,7 @@ if(`$dismInfo -contains 'State : Enable Pending') {return}
   $packageArgs += " /FeatureName:$packageName"
   
   Write-Host "Opening minimized PowerShell window and calling `'cmd.exe $packageArgs`'. If progress is taking a long time, please check that window. It also may not be 100% silent..." -ForegroundColor $Warning -BackgroundColor Black
-  $statements = $checkStatement + "cmd.exe $packageArgs | Tee-Object -FilePath `'$chocoInstallLog`';"
+  $statements = $checkStatement + "`ncmd.exe $packageArgs | Tee-Object -FilePath `'$chocoInstallLog`';"
   Start-ChocolateyProcessAsAdmin "$statements" -minimized -nosleep -validExitCodes @(0,1)
 
   Create-InstallLogIfNotExists $chocoInstallLog


### PR DESCRIPTION
Recently while creating a chocolatey package, I ran into an issue where trying to install a windows feature would fail on my 64-bit windows operating system with a message saying that I could not use the 32-bit version of DISM to manage features. The reason this was happening was because of the 32-bit redirection that occurs on a 64-bit operating system. I also found an issue (#378) that seems to be related because either the DISM was not in the path or more likely it was due to the lack of a new line between the closing curly brace and the "cmd" and resulted in "none" of the code being executed in the elevated shell.
