### PR TITLE
Resolve issue with DISM "missing" or with the 32-bit DISM being called on a 64-bit system

### DIFF
--- a/src/functions/Chocolatey-WindowsFeatures.ps1
+++ b/src/functions/Chocolatey-WindowsFeatures.ps1
@@ -33,7 +33,7 @@ if(`$dismInfo -contains 'State : Enable Pending') {return}
   $packageArgs += " /FeatureName:$packageName"
   
   Write-Host "Opening minimized PowerShell window and calling `'cmd.exe $packageArgs`'. If progress is taking a long time, please check that window. It also may not be 100% silent..." -ForegroundColor $Warning -BackgroundColor Black
-  $statements = $checkStatement + "cmd.exe $packageArgs | Tee-Object -FilePath `'$chocoInstallLog`';"
+  $statements = $checkStatement + "`ncmd.exe $packageArgs | Tee-Object -FilePath `'$chocoInstallLog`';"
   Start-ChocolateyProcessAsAdmin "$statements" -minimized -nosleep -validExitCodes @(0,1)
 
   Create-InstallLogIfNotExists $chocoInstallLog


### PR DESCRIPTION
Recently while creating a chocolatey package, I ran into an issue where trying to install a windows feature would fail on my 64-bit windows operating system with a message saying that I could not use the 32-bit version of DISM to manage features. The reason this was happening was because of the 32-bit redirection that occurs on a 64-bit operating system. I also found an issue (#378) that seems to be related because either the DISM was not in the path or more likely it was due to the lack of a new line between the closing curly brace and the "cmd" and resulted in "none" of the code being executed in the elevated shell.

After reading the "contributing" document, I implemented the fix in a branch and sent a new pull request.
