### PR TITLE
Fixed problem where CPU bits mismatches OS bits

### DIFF
--- a/src/helpers/functions/Get-ProcessorBits.ps1
+++ b/src/helpers/functions/Get-ProcessorBits.ps1
@@ -17,17 +17,26 @@ param(
 )
   Write-Debug "Running 'System-GetBits'"
 
-  #TODO: This is trivial at the moment, but Get-WmiObject Win32_Processor IS SLOW.
-  #      Can we cache this?
+	# Get address width for the Operating System (not the Processor)
+	$os		= Get-WmiObject Win32_OperatingSystem
+	$osArch = $os.OSArchitecture
 
-  # Get the address width
-    $proc = Get-WmiObject Win32_Processor
-    $procCount = (Get-WmiObject Win32_ComputerSystem).NumberofProcessors
-    if ($procCount -eq '1') {
-        $bits = $proc.AddressWidth
-    } else {
-        $bits = $proc[0].AddressWidth
-    }
+	# Detection for older systems
+	if (-Not $osArch) {
+		if ([System.IntPtr]::Size -eq 4) { 
+			$osArch = "32-bit"
+		} else {
+			$osArch = "64-bit"
+		}
+	}
+
+	# Integer
+	if ($osArch -eq '64-bit') {
+		$bits = 64
+	} else {
+		$bits = 32
+	}
+
 
   # Return bool|int
   if ("$compare" -ne '' -and $compare -eq $bits) {


### PR DESCRIPTION
Now looking at OS in stead of CPU.
Bonus: Skipping CPU is faster. Trying fallback for older OS.
I am on Linux, so I have only tested this using my common sense VM.
