### PR TITLE
[Enhancement] -quiet parameter that silences almost all output

### DIFF
--- a/src/chocolatey.ps1
+++ b/src/chocolatey.ps1
@@ -18,7 +18,7 @@
   [alias("params")][alias("parameters")][alias("pkgParams")][string]$packageParameters = '',
   [parameter(Position=1, ValueFromRemainingArguments=$true)]
   [string[]]$packageNames=@(''),
-  [switch] $logout = $true
+  [switch] $quiet = $false
 )
 
 [switch] $debug = $false
@@ -60,7 +60,7 @@ $h2 = '-------------------------'
 $globalConfig = ''
 $userConfig = ''
 $env:ChocolateyEnvironmentDebug = 'false'
-$env:ChocolateyEnvironmentLogOutput = 'true'
+$env:ChocolateyEnvironmentQuiet = 'false'
 $RunNote = "DarkCyan"
 $Warning = "Magenta"
 $ErrorColor = "Red"
@@ -73,8 +73,8 @@ if ($debug) {
   $env:ChocolateyEnvironmentDebug = 'true'
 }
 
-if ($logout -eq $false) {
-  $env:ChocolateyEnvironmentLogOutput = 'false'
+if ($quiet) {
+  $env:ChocolateyEnvironmentQuiet = 'true'
 }
 
 $installModule = Join-Path $nugetChocolateyPath (Join-Path 'helpers' 'chocolateyInstaller.psm1')
@@ -127,7 +127,7 @@ $packageParameters = $packageParameters.Replace("'","""")
 #main entry point
 Append-Log
 
-Write-Debug "Arguments: `$command = '$command'|`$packageNames='$packageNames'|`$source='$source'|`$version='$version'|`$allVersions=$allVersions|`$InstallArguments='$installArguments'|`$overrideArguments=$overrideArgs|`$force=$force|`$prerelease=$prerelease|`$localonly=$localonly|`$verbosity=$verbosity|`$debug=$debug|`$logout=$logout|`$name='$name'|`$ignoreDependencies=$ignoreDependencies|`$forceX86=$forceX86|`$packageParameters='$packageParameters'|PowerShellVersion=$($host.version)"
+Write-Debug "Arguments: `$command = '$command'|`$packageNames='$packageNames'|`$source='$source'|`$version='$version'|`$allVersions=$allVersions|`$InstallArguments='$installArguments'|`$overrideArguments=$overrideArgs|`$force=$force|`$prerelease=$prerelease|`$localonly=$localonly|`$verbosity=$verbosity|`$debug=$debug|`$quiet=$quiet|`$name='$name'|`$ignoreDependencies=$ignoreDependencies|`$forceX86=$forceX86|`$packageParameters='$packageParameters'|PowerShellVersion=$($host.version)"
 
 # run level environment variables
 

--- a/src/helpers/functions/Write-Host.ps1
+++ b/src/helpers/functions/Write-Host.ps1
@@ -12,7 +12,7 @@ param(
   "$(get-date -format 'yyyyMMdd-HH:mm:ss') [CHOCO] $Object"| Out-File -FilePath $chocoInstallLog -Force -Append
   
   $oc = Get-Command 'Write-Host' -Module 'Microsoft.PowerShell.Utility'
-  if($env:ChocolateyEnvironmentLogOutput -eq 'false') {
+  if($env:ChocolateyEnvironmentQuiet -eq 'true') {
     $oc = {}
   }
   


### PR DESCRIPTION
fix for issue #411 discussed at  https://groups.google.com/forum/#!topic/chocolatey/yCV3J6BuvpY

Added a new parameter, logout, which is true be default but now you can turn Write-Host off by setting it to true.
Tried to add tests for this but since the actual issue is Write-Host it gets hard to test for WH not being called, thus turning it off, and then Pester wont output anything. 
As I said I actually wrote some tests but they didn't feel right. 
Maybe I'm wrong here.
Tested locally with DSC (desired state configuration) and it work great.

Comments...
