### PR TITLE
Auto-uninstall via detecting changes in Add/Remove Programs registry keys

### DIFF
--- a/src/functions/Chocolatey-AutoUninstall.ps1
+++ b/src/functions/Chocolatey-AutoUninstall.ps1
@@ -1,0 +1,113 @@
+﻿function Chocolatey-AutoUninstall {
+<#
+.SYNOPSIS
+Uninstalls a package automatically
+
+.DESCRIPTION
+This will attempt to uninstall a package on your machine using information recorded during the install.
+
+.PARAMETER PackageFolder
+The folder the package installed to
+
+.PARAMETER PackageName
+The name of the package
+
+.EXAMPLE
+Chocolatey-AutoUninstall '__FOLDER__' '__NAME__'
+
+.OUTPUTS
+None
+
+.NOTES
+
+.LINK
+Install-ChocolateyInstallPackage
+#>
+param(
+  [string] $packageFolder,
+  [string] $packageName
+)
+  Write-Debug "Running 'Chocolatey-AutoUninstall' for $packageName in $packageFolder";
+
+  $uninstallKeysFile = join-path "$packageFolder" "$packageName-uninstallkeys.txt"
+  if (!(Test-Path $uninstallKeysFile)) {
+    throw "This package has a chocolateyInstall.ps1 without a chocolateyUninstall.ps1, and auto-uninstall failed. You will need to manually reverse whatever steps the installer did. Please ask the package maker to include a chocolateyUninstall.ps1 in the file to really remove the package."
+  }
+
+  write-host "Auto-uninstalling $packageName..."
+
+  # Import-Csv has no Encoding param in Powershell v2
+  # In powershell v2, need to force result of ConvertFrom-Csv to an array in case only one line in file
+  $uninstallKeys = @(Get-Content $uninstallKeysFile -Encoding UTF8 | ConvertFrom-Csv)
+
+  if ($uninstallKeys -eq $nil -or $uninstallKeys.Length -eq 0) {
+    throw "Blank auto-install information - you will need to manually uninstall $($packageName)."
+  }
+
+  $currentSID = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+  foreach ($uk in $uninstallKeys) {
+    if (($uk.SignficantUser) -and $($uk.SignficantUser -ne $currentSID)) {
+      Write-Debug "SID-clash: $($uk.SignficantUser) vs. $currentSID with $($uk.DisplayName), $($uk.Key)"
+      $otherSID = New-Object System.Security.Principal.SecurityIdentifier($uk.SignficantUser) 
+      $otherUser = $otherSID.Translate([System.Security.Principal.NTAccount]) 
+      throw "$packageName was installed per-user under $($otherUser.Value) account - switch to that user before uninstalling"
+    }
+  }
+
+  $allUninstallKeys = Get-UninstallerRegistryKeys
+
+  $uninstallKeys | ForEach-Object {
+    Write-Debug "Attempting uninstall via $_"
+    $found = $false
+    foreach ($now in $allUninstallKeys) {
+      if ($now.Key -eq $_.Key) {
+        $found = $true
+        if ($now.DisplayName -ne $_.DisplayName) {
+          Write-Host "Note: About to uninstall $($now.DisplayName), which was $($_.DisplayName) at install time"
+        } else {
+          Write-Host "Auto-uninstalling $($_.DisplayName) Add/Remove Programs entry"
+        }
+        $uninstallCommand = $now.UninstallCommand
+        Write-Debug "Uninstall command: $uninstallCommand"
+        if ($uninstallCommand -ne $_.UninstallCommand) {
+          Write-Debug "Note: Uninstall command was different at install time: $($_.UninstallCommand)"
+        }
+
+        # Massage msiexec to silent uninstalls
+        if ($uninstallCommand -match "^msiexec.exe\s+/[ix]\s*({[A-Z0-9\-]+})") {
+          $uninstallCommand = "msiexec.exe /x$($Matches[1]) /quiet"
+          Write-Debug "Updating MSI uninstall to be quiet with: $uninstallCommand"
+        }
+
+        # Split into program and args
+        if ($uninstallCommand.StartsWith("""")) {
+          $pos = $uninstallCommand.IndexOf('"', 1)
+          if ($pos -lt 0 ) { throw "Corrupt Uninstall command - unclosed quotes" }
+          $program = $uninstallCommand.Substring(1, $pos-1).Trim()
+          $args = $uninstallCommand.Substring($pos+1).Trim()
+        } else {
+          $pos = $uninstallCommand.IndexOf(' ', 1)
+          if ($pos -lt 0 ) {
+              $program = $uninstallCommand
+              $args = ''
+          } else {
+              $args = $uninstallCommand.Substring($pos+1).Trim()
+              $program = $uninstallCommand.Substring(0, $pos).Trim()
+          }
+        }
+        Write-Debug "Split into $program and $args"
+
+        $validExitCodes = @(0)
+        Start-ChocolateyProcessAsAdmin "$args" $program -validExitCodes $validExitCodes
+
+        $found = $true
+        break;
+      }
+    }
+    if (!($found)) {
+      Write-Host "Ignoring already deleted uninstall key $($_.Key), aka $($_.DisplayName)"
+    }
+  }
+
+  write-host "$packageName has been auto-uninstalled."
+}

--- a/src/functions/Chocolatey-NuGet.ps1
+++ b/src/functions/Chocolatey-NuGet.ps1
@@ -78,13 +78,15 @@ Write-Debug "Installing packages to `"$nugetLibPath`"."
 
             if ([System.IO.Directory]::Exists($packageFolder)) {
               try {
+                $beforeRegKeys = Get-UninstallerRegistryKeys
                 Delete-ExistingErrorLog $installedPackageName
                 Run-ChocolateyPS1 $packageFolder $installedPackageName "install" $installerArguments
                 Get-ChocolateyBins $packageFolder
                 if ($installedPackageName.ToLower().EndsWith('.extension')) {
                   Chocolatey-InstallExtension $packageFolder $installedPackageName
                 }
-
+                $afterRegKeys = Get-UninstallerRegistryKeys
+                Record-InstallerRegistryKeysDelta $installedPackageName $packageFolder $beforeRegKeys $afterRegKeys
               } catch {
                 Move-BadInstall $installedPackageName $installedPackageVersion $packageFolder
                 Write-Error "Package `'$installedPackageName v$installedPackageVersion`' did not install successfully: $($_.Exception.Message)"

--- a/src/functions/Get-UninstallerRegistryKeys.ps1
+++ b/src/functions/Get-UninstallerRegistryKeys.ps1
@@ -1,0 +1,50 @@
+
+# Leaning on info from http://community.spiceworks.com/how_to/show/2238-how-add-remove-programs-works
+# But ignoring WindowsInstaller value - seems set to 1 in some standard programs
+filter script:GoodUninstallKey {
+ if ($_.GetValue('DisplayName') -and $_.GetValue('UninstallString') -and $_.GetValue('SystemComponent', 0) -eq 0 `
+    -and !$_.GetValue('ParentKeyName') -and !$_.GetValue('ReleaseType') -and $_.PSChildName -notmatch "KB\d{6}")
+  { $_ }
+}
+
+function Get-UninstallerRegistryKeys {
+param(
+  [string]$outFile
+)
+  if ([intptr]::Size -eq 4 -and (Test-Path "$env:windir\sysnative")) {
+    # We're in 32-bit mode on a 64-bit box - need to upgrade myself for consistency and to catch any 64-bit installer activity
+    # This would have been much easier/cleaner in Powershell 3.0 with RegistryView, but we're sticking with Powershell v2...
+    # Looked/tried a few methods, but the most reliable seemed to be via recalling in 64-bit form and sending back via a temporary CSV file
+    $mypath = Join-Path "$env:ChocolateyInstall" 'functions\Get-UninstallerRegistryKeys.ps1'
+    $tmpFile = [System.IO.Path]::GetTempFileName()
+    & "$env:windir\sysnative\WindowsPowerShell\v1.0\powershell.exe" -command "& { . '$mypath'; Get-CompoundUninstallerKeys('$tmpFile') }"
+    # Import-Csv has no Encoding param in Powershell v2
+    $keys = Get-Content $tmpFile -Encoding UTF8 | ConvertFrom-Csv
+    Remove-Item $tmpFile
+    return $keys
+  } else {
+    $currentSID = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+    $keys = @()
+    @('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall', 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+      'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall', 'HKCU:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall') | ForEach-Object {
+      if (Test-Path $_) {
+        $significantUser = ''
+        if ($_.StartsWith('HKCU:')) {
+          $significantUser = $currentSID
+        }
+        Get-ChildItem -Path $_ | GoodUninstallKey | ForEach-Object {
+          $uninstallCommand = $_.GetValue('QuietUninstallString', '')
+          if (!($uninstallCommand)) {
+            $uninstallCommand = $_.GetValue('UninstallString')
+          }
+          $keys += New-Object PSObject -Property @{Key = $_.Name; DisplayName = $_.GetValue('DisplayName'); SignficantUser = $significantUser; UninstallCommand = $uninstallCommand}
+        }
+      }
+    }
+    if ($outFile) {
+      $keys | Export-CSV $outFile -Encoding UTF8 -Force
+    } else {
+      return $keys
+    }
+  }
+}

--- a/src/functions/Record-InstallerRegistryKeysDelta.ps1
+++ b/src/functions/Record-InstallerRegistryKeysDelta.ps1
@@ -1,0 +1,23 @@
+function Record-InstallerRegistryKeysDelta {
+param(
+  [string] $packageName,
+  [string] $packageFolder,
+  [PSObject[]] $beforeRegKeys,
+  [PSObject[]] $afterRegKeys
+)
+
+  $significantRegKeys = $afterRegKeys | Where-Object {
+    foreach ($old in $beforeRegKeys) {
+      if ($old.Key -eq $_.Key -and $old.DisplayName -eq $_.DisplayName -and $old.UninstallCommand -eq $_.UninstallCommand) { return $false }
+    }
+    $true
+  }
+
+  if ($significantRegKeys) {
+    Write-Host "Logging item(s) from Add/Remove Programs registry for future auto-uninstall:"
+    $significantRegKeys | ForEach-Object { Write-Host $_.DisplayName; Write-Debug $_ }
+
+    $uninstallKeysFile = join-path "$packageFolder" "$packageName-uninstallkeys.txt"
+    $significantRegKeys | Export-CSV $uninstallKeysFile -Encoding UTF8 -NoTypeInformation -Force
+  }
+}

--- a/src/functions/Run-ChocolateyPS1.ps1
+++ b/src/functions/Run-ChocolateyPS1.ps1
@@ -57,10 +57,9 @@ param(
           throw $errorContents
         }
       }
-    }
-
-    if ($installps1 -notlike '' -and $ps1 -like '') {
-      throw "This package has a chocolateyInstall.ps1 without a chocolateyUninstall.ps1. You will need to manually reverse whatever steps the installer did. Please ask the package maker to include a chocolateyUninstall.ps1 in the file to really remove the package."
+    } elseif ($installps1 -notlike '') {
+      #throw "This package has a chocolateyInstall.ps1 without a chocolateyUninstall.ps1. You will need to manually reverse whatever steps the installer did. Please ask the package maker to include a chocolateyUninstall.ps1 in the file to really remove the package."
+      Chocolatey-AutoUninstall $packageFolder $packageName
     }
   }
 }

--- a/tests/unit/Chocolatey-AutoUninstall.tests.ps1
+++ b/tests/unit/Chocolatey-AutoUninstall.tests.ps1
@@ -1,0 +1,144 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$common = Join-Path (Split-Path -Parent $here)  '_Common.ps1'
+$base = Split-Path -parent (Split-Path -Parent $here)
+
+. $common
+
+$data1 = New-Object PSObject -Property @{Key = "HKEY_LOCAL_MACHINE\Windows\stuff\fdsjklfds"; DisplayName = "My Exe 1.01"; SignficantUser = ''; UninstallCommand = """C:\Prog Files\someuninst.exe"" blah stuff"}
+$data2 = New-Object PSObject -Property @{Key = "HKEY_CURRENT_USER\fdsjklfds"; DisplayName = "MSITastic 1.01"; SignficantUser = ''; UninstallCommand = "msiexec.exe /i{fsdfds-453543-GHJGHJ}"}
+$data3 = New-Object PSObject -Property @{Key = "HKEY_CURRENT_USER\Windows\yada"; DisplayName = "dsadsa 1.01"; SignficantUser = '{54534}'; UninstallCommand = "msiexec.exe /x {fsd-453gfsdgfsd543-GHJGHJ}"}
+$packageFolder = 'TestDrive:\'
+$packageName = 'mypackage'
+$uninstallKeysFile = join-path "$packageFolder" "$packageName-uninstallkeys.txt"
+
+
+Describe "Chocolatey-AutoUninstall" {
+  Context "When uninstall data file is missing" {
+    Mock Start-ChocolateyProcessAsAdmin
+    if (Test-Path $uninstallKeysFile) { Remove-Item $uninstallKeysFile }
+
+    $aborted = $false
+    try {
+      Chocolatey-AutoUninstall $packageFolder $packageName
+    } catch {
+      $aborted = $true
+    }
+    It "should abort" {
+      Assert-MockCalled Start-ChocolateyProcessAsAdmin -Exactly 0
+      $aborted | Should Be $true
+    }
+  }
+
+  Context "When uninstall data file is empty" {
+    Mock Start-ChocolateyProcessAsAdmin
+    Setup -File "$packageName-uninstallkeys.txt" ""
+
+    $aborted = $false
+    try {
+      Chocolatey-AutoUninstall $packageFolder $packageName
+    } catch {
+      $aborted = $true
+    }
+    It "should abort" {
+      Assert-MockCalled Start-ChocolateyProcessAsAdmin -Exactly 0
+      $aborted | Should Be $true
+    }
+  }
+
+  Context "When uninstall data file contains an invalid key" {
+    Mock Start-ChocolateyProcessAsAdmin
+    Setup -File "$packageName-uninstallkeys.txt" "NotARegKey"
+
+    $aborted = $false
+    try {
+      Chocolatey-AutoUninstall $packageFolder $packageName
+    } catch {
+      $aborted = $true
+    }
+    It "should abort" {
+      Assert-MockCalled Start-ChocolateyProcessAsAdmin -Exactly 0
+      $aborted | Should Be $true
+    }
+  }
+
+  Context "When uninstall data indicates another user ran a per-user install" {
+    Mock Start-ChocolateyProcessAsAdmin
+    Mock Get-UninstallerRegistryKeys { @($data1, $data2) }
+    @($data3) | Export-CSV $uninstallKeysFile -Encoding UTF8 -Force
+
+    $aborted = $false
+    try {
+      Chocolatey-AutoUninstall $packageFolder $packageName
+    } catch {
+      $aborted = $true
+    }
+    It "should abort" {
+      Assert-MockCalled Get-UninstallerRegistryKeys -Exactly 0
+      Assert-MockCalled Start-ChocolateyProcessAsAdmin -Exactly 0
+      $aborted | Should Be $true
+    }
+  }
+
+  Context "When uninstall data indicates this user ran a per-user install" {
+    Mock Start-ChocolateyProcessAsAdmin
+    $dataMe = $data3
+    $dataMe.SignficantUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+    Mock Get-UninstallerRegistryKeys { @($data1, $data2, $dataMe) }
+    @($dataMe) | Export-CSV $uninstallKeysFile -Encoding UTF8 -Force
+
+    Chocolatey-AutoUninstall $packageFolder $packageName
+    It "should uninstall properly" {
+      Assert-MockCalled Get-UninstallerRegistryKeys -Exactly 1
+      Assert-MockCalled Start-ChocolateyProcessAsAdmin -Exactly 1
+    }
+  }
+
+  Context "When uninstall data file contains an valid but no longer present key" {
+    Mock Start-ChocolateyProcessAsAdmin
+    Mock Get-UninstallerRegistryKeys { @($data1, $data3) }
+    @($data2) | Export-CSV $uninstallKeysFile -Encoding UTF8 -Force
+
+    Chocolatey-AutoUninstall $packageFolder $packageName
+    It "should silently ignore the key" {
+      Assert-MockCalled Get-UninstallerRegistryKeys -Exactly 1
+      Assert-MockCalled Start-ChocolateyProcessAsAdmin -Exactly 0
+    }
+  }
+
+  Context "When uninstall exec is a quoted exe" {
+    Mock Start-ChocolateyProcessAsAdmin {} -Verifiable -ParameterFilter { $statements -eq "blah stuff" -and $exeToRun -eq "C:\Prog Files\someuninst.exe" }
+    Mock Get-UninstallerRegistryKeys { @($data1, $data2, $data3) }
+    @($data1) | Export-CSV $uninstallKeysFile -Encoding UTF8 -Force
+
+    Chocolatey-AutoUninstall $packageFolder $packageName
+    It "should run it as given" {
+      Assert-VerifiableMocks
+      Assert-MockCalled Get-UninstallerRegistryKeys -Exactly 1
+      Assert-MockCalled Start-ChocolateyProcessAsAdmin -Exactly 1
+    }
+  }
+
+  Context "When uninstall exec is a single msiexec.exe call" {
+    Mock Start-ChocolateyProcessAsAdmin {} -Verifiable -ParameterFilter { $statements -eq "/x{fsdfds-453543-GHJGHJ} /quiet" -and $exeToRun -eq "msiexec.exe" }
+    Mock Get-UninstallerRegistryKeys { @($data1, $data2, $data3) }
+    @($data2) | Export-CSV $uninstallKeysFile -Encoding UTF8 -Force
+
+    Chocolatey-AutoUninstall $packageFolder $packageName
+    It "should run it quietly" {
+      Assert-MockCalled Get-UninstallerRegistryKeys -Exactly 1
+      Assert-MockCalled Start-ChocolateyProcessAsAdmin -Exactly 1
+      Assert-VerifiableMocks
+    }
+  }
+
+  Context "When uninstall exec is in two parts" {
+    Mock Start-ChocolateyProcessAsAdmin
+    Mock Get-UninstallerRegistryKeys { @($data1, $data2, $data3) }
+    @($data1, $data2) | Export-CSV $uninstallKeysFile -Encoding UTF8 -Force
+
+    Chocolatey-AutoUninstall $packageFolder $packageName
+    It "should run it as given" {
+      Assert-MockCalled Start-ChocolateyProcessAsAdmin -Exactly 2
+    }
+  }
+}

--- a/tests/unit/Record-InstallerRegistryKeysDelta.tests.ps1
+++ b/tests/unit/Record-InstallerRegistryKeysDelta.tests.ps1
@@ -1,0 +1,81 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$common = Join-Path (Split-Path -Parent $here)  '_Common.ps1'
+. $common
+
+$data1 = New-Object PSObject -Property @{Key = "HKEY_LOCAL_MACHINE\Windows\fdsjklfds"; DisplayName = "My Exe 1.01"; SignficantUser = ''; UninstallCommand = """C:\P F\someuninst.exe"" blah stuff"}
+$data2 = New-Object PSObject -Property @{Key = "HKEY_CURRENT_USER\fdsjklfds"; DisplayName = "MSITastic 1.01"; SignficantUser = ''; UninstallCommand = "msiexec.exe /i{fsdfds-453543-GHJGHJ}"}
+$data2a = New-Object PSObject -Property @{Key = "HKEY_CURRENT_USER\fdsjklfds"; DisplayName = "MSITastic 1.02"; SignficantUser = ''; UninstallCommand = "msiexec.exe /i{fsdfds-453543-GHJGHJ}"}
+$data2b = New-Object PSObject -Property @{Key = "HKEY_CURRENT_USER\fdsjklfds"; DisplayName = "MSITastic 1.01"; SignficantUser = ''; UninstallCommand = "msiexec.exe /i{fsdfgdfgfdJGHJ}"}
+$data3 = New-Object PSObject -Property @{Key = "HKEY_CURRENT_USER\fdsjklfdsfsfds"; DisplayName = "Blah v2"; SignficantUser = ''; UninstallCommand = "msiexec.exe /i{fsdfgdfgfdJGHJ}"}
+
+$packageName = 'mypackage'
+$packageFolder = 'TestDrive:\'
+$uninstallKeysFile = join-path "$packageFolder" "$packageName-uninstallkeys.txt"
+
+Describe "When calling Record-InstallerRegistryKeysDelta" {
+
+  Context "When no new registry key appears during the install" {
+    $same = @($data1)
+    if (Test-Path $uninstallKeysFile) { Remove-Item $uninstallKeysFile }
+
+    Record-InstallerRegistryKeysDelta $packageName $packageFolder $same $same
+
+    It "should result in no uninstallkeys file" {
+      Test-Path $uninstallKeysFile | Should Be $false
+    }
+  }
+
+  Context "When a new registry key appears during the install" {
+    $before = @($data1)
+    $after = @($data1, $data2)
+
+    Record-InstallerRegistryKeysDelta $packageName $packageFolder $before $after
+
+    It "should be noted for later" {
+      # In powershell v2, need to force result of ConvertFrom-Csv to an array
+      $uninstallKeys = @(Get-Content $uninstallKeysFile -Encoding UTF8 | ConvertFrom-Csv)
+      $uninstallKeys.Length | Should Be 1
+      $uninstallKeys[0].DisplayName | Should Be "MSITastic 1.01"
+    }
+  }
+
+  Context "When a existing registry key changes DisplayName during the install" {
+    $before = @($data1, $data2)
+    $after = @($data1, $data2a)
+
+    Record-InstallerRegistryKeysDelta $packageName $packageFolder $before $after
+
+    It "should be noted for later" {
+      $uninstallKeys = @(Get-Content $uninstallKeysFile -Encoding UTF8 | ConvertFrom-Csv)
+      $uninstallKeys.Length | Should Be 1
+      $uninstallKeys[0].DisplayName | Should Be "MSITastic 1.02"
+    }
+  }
+
+  Context "When a existing registry key changes UninstallCommand during the install" {
+    $before = @($data1, $data2)
+    $after = @($data1, $data2b)
+
+    Record-InstallerRegistryKeysDelta $packageName $packageFolder $before $after
+
+    It "should be noted for later" {
+      $uninstallKeys = @(Get-Content $uninstallKeysFile -Encoding UTF8 | ConvertFrom-Csv)
+      $uninstallKeys.Length | Should Be 1
+      $uninstallKeys[0].UninstallCommand | Should Be "msiexec.exe /i{fsdfgdfgfdJGHJ}"
+    }
+  }
+
+  Context "When two keys appear" {
+    $before = @($data1)
+    $after = @($data1, $data2, $data3)
+
+    Record-InstallerRegistryKeysDelta $packageName $packageFolder $before $after
+
+    It "they both are noted for later" {
+      $uninstallKeys = @(Get-Content $uninstallKeysFile -Encoding UTF8 | ConvertFrom-Csv)
+      $uninstallKeys.Length | Should Be 2
+      $uninstallKeys[0].DisplayName | Should Be "MSITastic 1.01"
+      $uninstallKeys[1].DisplayName | Should Be "Blah v2"
+    }
+  }
+}


### PR DESCRIPTION
Snapshot various Add/Remove Programs registry areas before & after running a chocolatey install so it can log the entries to play for later automated uninstallation. Should cope with 32/64 bit mode and standard/per-user installs.