### PR TITLE
Get-BinRoot defaulted to "C:\" instead of "C:\tools"

### DIFF
--- a/src/helpers/functions/Get-BinRoot.ps1
+++ b/src/helpers/functions/Get-BinRoot.ps1
@@ -9,12 +9,6 @@ function Get-BinRoot {
 
   $binRoot = ''
 
-  # Clean up wrongfully set C:\
-  if ($env:ChocolateyBinRoot -imatch "^\w:\\{0,1}$") {
-    # Read but untested: Setting a variable = an empty string will remove it completely.
-    $env:ChocolateyBinRoot = ''
-  }
-
   # For now, check old var first
   if ($env:ChocolateyBinRoot -eq $null) { # If no value
     if ($env:chocolatey_bin_root -eq $null) { # Try old var

--- a/src/helpers/functions/Get-BinRoot.ps1
+++ b/src/helpers/functions/Get-BinRoot.ps1
@@ -12,7 +12,7 @@ function Get-BinRoot {
   # For now, check old var first
   if ($env:ChocolateyBinRoot -eq $null) { # If no value
     if ($env:chocolatey_bin_root -eq $null) { # Try old var
-      $binRoot = join-path $env:systemdrive 'tools'
+      $env:ChocolateyBinRoot = join-path $env:systemdrive 'tools'
     }
     else {
       $env:ChocolateyBinRoot = $env:chocolatey_bin_root

--- a/src/helpers/functions/Get-BinRoot.ps1
+++ b/src/helpers/functions/Get-BinRoot.ps1
@@ -9,10 +9,16 @@ function Get-BinRoot {
 
   $binRoot = ''
 
+  # Clean up wrongfully set C:\
+  if ($env:ChocolateyBinRoot -eq $env:systemdrive) {
+    # Read but untested: Setting a variable = an empty string will remove it completely.
+    $env:ChocolateyBinRoot = ''
+  }
+
   # For now, check old var first
   if ($env:ChocolateyBinRoot -eq $null) { # If no value
     if ($env:chocolatey_bin_root -eq $null) { # Try old var
-      $binRoot = join-path $env:systemdrive 'tools'
+      $env:ChocolateyBinRoot = join-path $env:systemdrive 'tools'
     }
     else {
       $env:ChocolateyBinRoot = $env:chocolatey_bin_root

--- a/src/helpers/functions/Get-BinRoot.ps1
+++ b/src/helpers/functions/Get-BinRoot.ps1
@@ -10,7 +10,7 @@ function Get-BinRoot {
   $binRoot = ''
 
   # Clean up wrongfully set C:\
-  if ($env:ChocolateyBinRoot -eq $env:systemdrive) {
+  if ($env:ChocolateyBinRoot -imatch "^\w:\\{0,1}$") {
     # Read but untested: Setting a variable = an empty string will remove it completely.
     $env:ChocolateyBinRoot = ''
   }

--- a/src/helpers/functions/Get-BinRoot.ps1
+++ b/src/helpers/functions/Get-BinRoot.ps1
@@ -9,10 +9,16 @@ function Get-BinRoot {
 
   $binRoot = ''
 
+  # Clean up wrongfully set C:\
+  if ($env:ChocolateyBinRoot -imatch "^\w:\\{0,1}$") {
+    # Read but untested: Setting a variable = an empty string will remove it completely.
+    $env:ChocolateyBinRoot = ''
+  }
+
   # For now, check old var first
   if ($env:ChocolateyBinRoot -eq $null) { # If no value
     if ($env:chocolatey_bin_root -eq $null) { # Try old var
-      $binRoot = join-path $env:systemdrive 'tools'
+      $env:ChocolateyBinRoot = join-path $env:systemdrive 'tools'
     }
     else {
       $env:ChocolateyBinRoot = $env:chocolatey_bin_root


### PR DESCRIPTION
Line 15 set $binRoot to C:\tools, but did not set $env:ChocolateyBinRoot. Thus, the expression on line 23 evaluates $false (because $env:ChocolateyBinRoot is still $null), so line 25 overwrites $binRoot with just "C:\".
