### PR TITLE
Improve Chocolatey List LocalOnly performance

### DIFF
--- a/src/functions/Chocolatey-List.ps1
+++ b/src/functions/Chocolatey-List.ps1
@@ -25,10 +25,12 @@ param(
       Write-Host $line
     }
   } else {
-    $srcArgs = Get-SourceArguments $source
-
+  
+    $srcArgs = ""
     if ($localonly) {
       $srcArgs = "-Source $nugetLibPath"
+    } else {
+		$srcArgs = Get-SourceArguments $source
     }
 
     $parameters = "list"


### PR DESCRIPTION
Moves Get-SourceArguments into an else check so that it's only called if we're not checking the local package list. Improves performance since we're only checking the local configuration files for source if we have to.
