### PR TITLE
(GH-432) Corrected grammar used in output messages

### DIFF
--- a/src/functions/Chocolatey-Help.ps1
+++ b/src/functions/Chocolatey-Help.ps1
@@ -47,7 +47,7 @@ example: chocolatey install packages.config
 example: chocolatey installmissing nunit
 example: chocolatey update nunit -source http://somelocalfeed.com/nuget/
 example: chocolatey help
-example: chocolatey list (might take awhile)
+example: chocolatey list (might take a while)
 example: chocolatey list nunit
 example: chocolatey version
 example: chocolatey version nunit

--- a/src/functions/Run-ChocolateyProcess.ps1
+++ b/src/functions/Run-ChocolateyProcess.ps1
@@ -5,7 +5,7 @@ param(
   [switch] $elevated
 )
 
-  Write-Host "Running $file $arguments. This may take awhile and permissions may need to be elevated, depending on the package.";
+  Write-Host "Running $file $arguments. This may take a while and permissions may need to be elevated, depending on the package.";
   $psi = new-object System.Diagnostics.ProcessStartInfo $file;
   $psi.Arguments = $arguments;
   #$psi.Verb = "runas";

--- a/src/helpers/functions/Start-ChocolateyProcessAsAdmin.ps1
+++ b/src/helpers/functions/Start-ChocolateyProcessAsAdmin.ps1
@@ -20,7 +20,7 @@ param(
     }
   }
 @"
-Elevating Permissions and running $exeToRun $wrappedStatements. This may take awhile, depending on the statements.
+Elevating Permissions and running $exeToRun $wrappedStatements. This may take a while, depending on the statements.
 "@ | Write-Host
 
   $psi = new-object System.Diagnostics.ProcessStartInfo;


### PR DESCRIPTION
It was noted by Chocolatey User that "awhile" should be "a while".  This has been corrected in this commit.
