### PR TITLE
WebFile redirecter

### DIFF
--- a/src/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -73,7 +73,10 @@ param(
   }
 
   # Check for mapping of url to another
-  $url = Get-RedirectedWebFileUrl $packageName $url
+  $returnObject = Get-MappedChocolateyUrl $packageName $url
+  if ($returnObject -and $returnObject.newUrl) {
+    $url = $returnObject.newUrl
+  }
 
   #$downloader = new-object System.Net.WebClient
   #$downloader.DownloadFile($url, $fileFullPath)
@@ -131,4 +134,38 @@ param(
   # $url is already set properly to the used location.
   Write-Debug "Verifying downloaded file is not known to contain viruses. FilePath: `'$fileFullPath`'."
   Get-VirusCheckValid -location $url -file $fileFullPath
+}
+
+<#
+.SYNOPSIS
+Extension point for url logging/re-mapping code
+
+.PARAMETER packageName
+The name of the package we want to download - this is arbitrary, call it whatever you want.
+It's recommended you call it the same as your nuget package id.
+
+.PARAMETER url
+This is the url to be redirected/logged/whatever.
+
+.NOTES
+If changing the url, it should return the updated value in the newUrl property of a PSObject, or $null if no update
+#>
+function Get-MappedChocolateyUrl {
+param(
+  [string] $packageName,
+  [string] $url
+)
+  $returnObject = $null
+
+  if (Get-Command Get-UserChocolateyWebFileUrl -errorAction SilentlyContinue)
+  {
+    Write-Debug "Running Get-UserChocolateyWebFileUrl extension..."
+    $returnObject = Get-UserChocolateyWebFileUrl $packageName $url
+  }
+
+  if (!$returnObject) {
+    $returnObject = Get-RedirectedWebFileUrl $packageName $url
+  }
+
+  return $returnObject
 }

--- a/src/helpers/functions/Get-RedirectedWebFileUrl.ps1
+++ b/src/helpers/functions/Get-RedirectedWebFileUrl.ps1
@@ -19,6 +19,7 @@ Get-RedirectedWebFileUrl 'mycoolapp' 'http://www.coolco.com/download?app=coolapp
 
 .NOTES
 Uses the environment variable 'ChocolateyWebFileRedirecterCsv' as a source for the mapping CSV
+returns with the redirected url in the newUrl property of a PSObject, or $null if no mapping
 
 .LINK
 Get-ChocolateyWebFile
@@ -65,13 +66,13 @@ param(
           throw "Could not join $redirecterCsvLocation and $maybePartialRedirectedUrl"
         } else {
           Write-Debug "Redirecting to $redirectedUrl"
-          $url = $redirectedUrl
+          return New-Object -TypeName PSObject -Property @{newUrl=$redirectedUrl}
         }
       }
     }
   }
   
-  return $url
+  return $null
 }
 
 function Get-UTF8Content {

--- a/tests/unit/Get-RedirectedWebFileUrl.tests.ps1
+++ b/tests/unit/Get-RedirectedWebFileUrl.tests.ps1
@@ -26,8 +26,8 @@ Describe "Get-RedirectedWebFileUrl with no mapping setting" {
     It "should not attempt to download the mapping CSV" {
       Assert-MockCalled Get-UTF8Content -Exactly 0
     }
-    It "should be returned unchanged" {
-      $returnValue | Should Be $urlUnknown
+    It "should not return an update" {
+      $returnValue | Should Be $null
     }
   }
 }
@@ -42,8 +42,8 @@ Describe "Get-RedirectedWebFileUrl with an example mapping defined" {
     It "should attempt to download the mapping CSV" {
       Assert-MockCalled Get-UTF8Content -Exactly 1
     }
-    It "should be returned unchanged" {
-      $returnValue | Should Be $urlUnknown
+    It "should not return an update" {
+      $returnValue | Should Be $null
     }
   }
 
@@ -54,7 +54,7 @@ Describe "Get-RedirectedWebFileUrl with an example mapping defined" {
       Assert-MockCalled Get-UTF8Content -Exactly 1
     }
     It "should be returned in the new form" {
-      $returnValue | Should Be $url1Redirected
+      $returnValue.newUrl | Should Be $url1Redirected
     }
   }
 }


### PR DESCRIPTION
Allow switching URLs in packages for locally-controlled equivalents in Get-ChocolateyWebFile.
This enables packages to install without direct Internet access, and manual caching.

Enabled via the environment variable "ChocolateyWebFileRedirecterCsv", which should point to a uri or filepath of a CSV file in UTF8 (or ASCII) form containing "url,redirectedUrl" columns and one url mapping per row.
