### PR TITLE
Fix for checksum unit tests to get TestDrive path using Get-PSDrive

### DIFF
--- a/tests/unit/Get-ChecksumValid.tests.ps1
+++ b/tests/unit/Get-ChecksumValid.tests.ps1
@@ -7,7 +7,7 @@ function setup-testfile {
   $filePath = 'some\file.txt'
   Setup -File "$filePath" 'yo yo'
 
-  Join-Path (Join-Path $env:Temp 'pester') "$filePath"
+  Join-Path ((Get-PSDrive -Name TestDrive).Root) "$filePath"
 }
 
   Context "When a good checksum is provided" {


### PR DESCRIPTION
As per this dicussion:

https://groups.google.com/forum/#!topic/chocolatey/9oQwi0-z3K0

It's a fix for the 5 checksum unit tests that were failing.
