### PR TITLE
Improved Remove-BinFile to remove shim .exes when uninstalling a package

### DIFF
--- a/src/functions/Remove-BinFile.ps1
+++ b/src/functions/Remove-BinFile.ps1
@@ -7,6 +7,7 @@ param(
 
   $packageBatchFileName = Join-Path $nugetExePath "$name.bat"
   $packageBashFileName = Join-Path $nugetExePath "$name"
+  $packageShimFileName = Join-Path $nugetExePath "$name.exe"
   $path = $path.ToLower().Replace($nugetPath.ToLower(), "%DIR%..\").Replace("\\","\")
   $pathBash = $path.Replace("%DIR%..\","`$DIR/../").Replace("\","/")
   Write-Debug "Attempting to remove the batch and bash shortcuts: $packageBatchFileName and $packageBashFileName"
@@ -15,13 +16,21 @@ param(
     Remove-Item $packageBatchFileName
   }
   else {
-    Write-Host "Tried to remove batch file $packageBatchFileName but it was already removed." -ForegroundColor $Note
+    Write-Debug "Tried to remove batch file $packageBatchFileName but it was already removed."
   }
   if (Test-Path $packageBashFileName) {
     Write-Host "Removing bash file $packageBashFileName which pointed to `'$path`'." -ForegroundColor $Note
     Remove-Item $packageBashFileName
   }
   else {
-    Write-Host "Tried to remove bash file $packageBashFileName but it was already removed." -ForegroundColor $Note
+    Write-Debug "Tried to remove bash file $packageBashFileName but it was already removed."
+  }
+  Write-Debug "Attempting to remove the shim: $packageShimFileName"
+  if (Test-Path $packageShimFileName) {
+    Write-Host "Removing shim $packageShimFileName which pointed to `'$path`'." -ForegroundColor $Note
+    Remove-Item $packageShimFileName
+  }
+  else {
+    Write-Debug "Tried to remove shim $packageShimFileName but it was already removed."
   }
 }


### PR DESCRIPTION
Until now, Remove-BinFile only knew about the old-method batch redirects, so shimgen-generated exes were left behind.
