### PR TITLE
add CreateNoWindow  to Run-NuGet.ps1

### DIFF
--- a/src/functions/Run-NuGet.ps1
+++ b/src/functions/Run-NuGet.ps1
@@ -26,6 +26,7 @@ param(
   $process.StartInfo.RedirectStandardOutput = $true
   $process.StartInfo.RedirectStandardError = $true
   $process.StartInfo.UseShellExecute = $false
+  $process.StartInfo.CreateNoWindow = $true  
 
   $process.Start() | Out-Null
   $process.WaitForExit()


### PR DESCRIPTION
Seems no one can work out why chocolatey gui doesnt popup a nuget dialog :)

Wondering if we can just make it a non issue by adding `CreateNoWindow` to `Run-NuGet.ps1`
