### PR TITLE
Update Uninstall-ChocolateyPackage.ps1

### DIFF
--- a/src/helpers/functions/Uninstall-ChocolateyPackage.ps1
+++ b/src/helpers/functions/Uninstall-ChocolateyPackage.ps1
@@ -48,7 +48,7 @@ param(
   $overrideArguments = $env:chocolateyInstallOverride;
     
   if ($fileType -like 'msi') {
-    $msiArgs = "/x" 
+    $msiArgs = "/x `"$file`"" 
     if ($overrideArguments) { 
       $msiArgs = "$msiArgs $additionalInstallArgs";
       write-host "Overriding package arguments with `'$additionalInstallArgs`'";


### PR DESCRIPTION
# I tested this change when uninstalling the NSClient++ Nagios msi package and it worked fine.
# Might not be backward compatible if $file parameter doesn't refer to the actual msi-package used
# when installing.

Uninstall-ChocolateyPackage 'nscp' 'msi' '/passive' <PATH_TO_MSI_FILE>
