### PR TITLE
Added functionality to support installArguments in packages.config

### DIFF
--- a/src/functions/Chocolatey-PackagesConfig.ps1
+++ b/src/functions/Chocolatey-PackagesConfig.ps1
@@ -22,7 +22,7 @@ param(
 
   $xml = [xml] (Get-Content $packagesConfigPath)
   $xml.packages.package | ?{ $_.id -ne '' -and $_.id -ne $null} | %{
-    Write-Debug "Calling Chocolatey-Install -packageName $_.id -source $_.source -version $_.version"
-    Chocolatey-Install -packageName $_.id -source $_.source -version $_.version
+    Write-Debug "Calling Chocolatey-Install -packageName $_.id -source $_.source -version $_.version -installArguments $_.installArguments"
+    Chocolatey-Install -packageName $_.id -source $_.source -version $_.version -installerArguments $_.installArguments
   }
 }

--- a/tests/unit/Chocolatey-PackagesConfig.tests.ps1
+++ b/tests/unit/Chocolatey-PackagesConfig.tests.ps1
@@ -153,6 +153,54 @@ Describe "Chocolatey-PackagesConfig" {
     }
   }
 
+  Context "When calling Chocolatey-PackagesConfig with a packages.config manifest that has installArguments" {
+    Mock Chocolatey-Install {} -Verifiable {$packageName -eq 'chocolateytestpackage' -and $version -eq '0.1' -and $installerArguments -eq '/test /install /arguments'}
+    Mock Chocolatey-NuGet {} 
+  
+    Setup -File 'packages.config' @"
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="chocolateytestpackage" version="0.1" installArguments="/test /install /arguments" />
+</packages>  
+"@
+  
+    Chocolatey-PackagesConfig "TestDrive:\packages.config"
+  
+    It "should execute the contents of the packages.config" {}
+
+    It "should call Chocolatey-Install" {
+      Assert-VerifiableMocks
+    }
+    
+    It "should not call Chocolatey-Nuget" {
+      Assert-mockCalled Chocolatey-Nuget 0
+    }
+  }
+
+  Context "When calling Chocolatey-PackagesConfig with a packages.config manifest that has no installArguments attribute" {
+    Mock Chocolatey-Install {} -Verifiable {$packageName -eq 'chocolateytestpackage' -and $version -eq '0.1' -and $installerArguments -eq ''}
+    Mock Chocolatey-NuGet {} 
+  
+    Setup -File 'packages.config' @"
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="chocolateytestpackage" version="0.1" />
+</packages>  
+"@
+  
+    Chocolatey-PackagesConfig "TestDrive:\packages.config"
+  
+    It "should execute the contents of the packages.config" {}
+
+    It "should call Chocolatey-Install" {
+      Assert-VerifiableMocks
+    }
+    
+    It "should not call Chocolatey-Nuget" {
+      Assert-mockCalled Chocolatey-Nuget 0
+    }
+  }
+
   Context "With a packages.config manifest that has ruby packages" {
     Mock Chocolatey-Install {} -Verifiable {$packageName -eq 'chocolateytestpackage' -and $version -eq '0.1' -and $source -eq 'ruby'}
     Mock Chocolatey-NuGet {}


### PR DESCRIPTION
This Pull Requests add an additional attribute to the package.config named "installArguments".
This attribute basically does the same as you would provide the "installArguments" paramer
 to the "chocolatey install" command.

Originaly sent with https://github.com/chocolatey/chocolatey/pull/336#discussion_r6380358 but from the wrong branch.
