### PR TITLE
[BUG] Install error throws another error due to true instead of $true

### DIFF
--- a/src/functions/Chocolatey-NuGet.ps1
+++ b/src/functions/Chocolatey-NuGet.ps1
@@ -90,7 +90,7 @@ Write-Debug "Installing packages to `"$nugetLibPath`"."
                 Write-Error "Package `'$installedPackageName v$installedPackageVersion`' did not install successfully: $($_.Exception.Message)"
                 if ($badPackages -ne '') { $badPackages += ', '}
                 $badPackages += "$packageName"
-                $chocolateyErrored = true
+                $chocolateyErrored = $true
               }
             }
           }


### PR DESCRIPTION
Running "choco install xyx" failed and I got a hard error:

```
The term 'true' is not recognized as the name of a cmdlet, function,
script file, or operable program. Check the spelling of the name, or if
a path was included, verify that the path is correct and try again.

Command 'install' failed (sometimes this indicates a partial
failure).
```
