### PR TITLE
[Bug] Posh v3+ ignores -Wait when run from cmd.exe

### DIFF
--- a/src/helpers/functions/Get-ChocolateyUnzip.ps1
+++ b/src/helpers/functions/Get-ChocolateyUnzip.ps1
@@ -80,6 +80,7 @@ param(
   $unzipOps = {
     param($7zip, $destination, $fileFullPath, [ref]$exitCodeRef)
     $p = Start-Process $7zip -ArgumentList "x -o`"$destination`" -y `"$fileFullPath`"" -Wait -WindowStyle Hidden -PassThru
+    Wait-Process -InputObject $p
     $exitCodeRef.Value = $p.ExitCode
   }
 


### PR DESCRIPTION
Running choco install in a cmd window, spew out this error message:

```
DEBUG: wrapping 7za invocation with Write-FileUpdateLog
DEBUG: Running 'Write-FileUpdateLog' with logFilePath:'C:\Chocolatey\lib\scala.portable.2.10.4\scala.portableInstall.zip.txt'',
locationToMonitor:C:\Tools, Operation: '
    param($7zip, $destination, $fileFullPath, [ref]$exitCodeRef)
    $p = Start-Process $7zip -ArgumentList "x -o`"$destination`" -y `"$fileFullPath`"" -Wait -WindowStyle Hidden -PassThru
    $exitCodeRef.Value = $p.ExitCode
  '
DEBUG: Tracking current state of 'C:\Tools'
DEBUG: 7za exit code:
DEBUG: Renaming 'C:\Users\Claudio\AppData\Local\Temp\chocolatey\scala.portable\success.log' to
'C:\Users\Claudio\AppData\Local\Temp\chocolatey\scala.portable\success.log.old'
Write-Error : scala.portable did not finish successfully. Boo to the chocolatey gods!
-----------------------
[ERROR] 7-Zip signalled an unknown error (code )
-----------------------
At C:\Chocolatey\chocolateyInstall\helpers\functions\Write-ChocolateyFailure.ps1:30 char:3
+   Write-Error $errorMessage
+   ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Write-Error
```

Oddly enough, the error code is not set. Looking in the update log, it
seems that 7za stopped halfway through or was just not finished yet.

Might be related to
http://social.technet.microsoft.com/forums/en-US/3ec5c7b5-4a36-4890-98c2-ae654993f173/powershell-script-startprocess-no-exitcode-when-run-in-sccm-tasksequence
