### PR TITLE
Fixes issue I had with ExitCode not being set

### DIFF
--- a/src/helpers/functions/Get-ChocolateyUnzip.ps1
+++ b/src/helpers/functions/Get-ChocolateyUnzip.ps1
@@ -80,6 +80,7 @@ param(
   $unzipOps = {
     param($7zip, $destination, $fileFullPath, [ref]$exitCodeRef)
     $p = Start-Process $7zip -ArgumentList "x -o`"$destination`" -y `"$fileFullPath`"" -Wait -WindowStyle Hidden -PassThru
+    Wait-Process -InputObject $p
     $exitCodeRef.Value = $p.ExitCode
   }
 


### PR DESCRIPTION
http://connect.microsoft.com/PowerShell/feedback/details/774903/powershell-3-0-start-process-disregards-wait-parameter-when-invoked-remotely
Seems to be related to this Connect issue, workaround listed fixed my issue

The error I was getting was:

```
DEBUG: 7za exit code:
Write-Error : GitReleaseNotes did not finish successfully. Boo to the chocolatey gods!
-----------------------
[ERROR] 7-Zip signalled an unknown error (code )
-----------------------
At C:\ProgramData\chocolatey\chocolateyinstall\helpers\functions\Write-ChocolateyFailure.ps1:30 char:3
+   Write-Error $errorMessage
+   ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Write-Error
```

Which shows the exit code is not being set so the error is being raised
