### PR TITLE
Improve the condition whether NetWorkCredential is valid or not

### DIFF
--- a/src/helpers/functions/Get-WebFile.ps1
+++ b/src/helpers/functions/Get-WebFile.ps1
@@ -30,7 +30,8 @@ param(
   if (!$webclient.Proxy.IsBypassed($url))
   {
     $creds = [net.CredentialCache]::DefaultCredentials
-    if ($creds -eq $null) {
+    if ($creds -eq $null -or
+        $creds.UserName -eq "" -or $creds.Password -eq "") {
       Write-Debug "Default credentials were null. Attempting backup method"
       $cred = get-credential
       $creds = $cred.GetNetworkCredential();

--- a/src/helpers/functions/Get-WebHeaders.ps1
+++ b/src/helpers/functions/Get-WebHeaders.ps1
@@ -13,7 +13,8 @@ param(
   if (!$client.Proxy.IsBypassed($url))
   {
     $creds = [Net.CredentialCache]::DefaultCredentials
-    if ($creds -eq $null) {
+    if ($creds -eq $null -or
+        $creds.UserName -eq "" -or $creds.Password -eq "") {
       Write-Debug "Default credentials were null. Attempting backup method"
       $cred = Get-Credential
       $creds = $cred.GetNetworkCredential();


### PR DESCRIPTION
This PR is new version of the PR #332 .

`[net.CredentialCache]::DefaultCredentials` may return a default `System.Net.NetworkCredential` instance.
But Chocolatey checks only if `$cred` is null or not for the need of NetworkCredential.
It may have another check whether this variable is the default NetworkCredential instance or not.
