### PR TITLE
Make the temp directory configurable

### DIFF
--- a/chocolateyInstall/InstallChocolatey.ps1
+++ b/chocolateyInstall/InstallChocolatey.ps1
@@ -20,7 +20,7 @@
 #$url = "http://chocolatey.org/packages/chocolatey/DownloadPackage"
 $url = "http://chocolatey.org/api/v2/package/chocolatey/"
 #$url = "http://chocolatey.org/api/v1/package/chocolatey"
-$chocTempDir = Join-Path $env:TEMP "chocolatey"
+$chocTempDir = Get-ChocolateyTempDir
 $tempDir = Join-Path $chocTempDir "chocInstall"
 if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
 $file = Join-Path $tempDir "chocolatey.zip"

--- a/nuget/tools/chocolateysetup.psm1
+++ b/nuget/tools/chocolateysetup.psm1
@@ -198,7 +198,7 @@ param(
   if(!(test-path "$env:windir\Microsoft.Net\$fx\v4.0.30319")) {
     $NetFx4ClientUrl = 'http://download.microsoft.com/download/5/6/2/562A10F9-C9F4-4313-A044-9C94E0A8FAC8/dotNetFx40_Client_x86_x64.exe'
     $NetFx4FullUrl = 'http://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe'
-    Install-ChocolateyPackage "NetFx4.0" 'exe' -silentArgs "/q /norestart /repair /log `'$env:Temp\NetFx4Install.log`'" -url "$NetFx4ClientUrl" -url64bit "$NetFx4ClientUrl" -validExitCodes @(0, 3010)
+    Install-ChocolateyPackage "NetFx4.0" 'exe' -silentArgs "/q /norestart /repair /log `'$(Get-TempDir)\NetFx4Install.log`'" -url "$NetFx4ClientUrl" -url64bit "$NetFx4ClientUrl" -validExitCodes @(0, 3010)
   }
 }
 

--- a/src/functions/Delete-ExistingErrorLog.ps1
+++ b/src/functions/Delete-ExistingErrorLog.ps1
@@ -4,7 +4,7 @@ param(
 )
   Write-Debug "Running 'Delete-ExistingErrorLog' for $packageName";
 
-  $chocTempDir = Join-Path $env:TEMP "chocolatey"
+  $chocTempDir = Get-ChocolateyTempDir
   $tempDir = Join-Path $chocTempDir "$packageName"
   $failureLog = Join-Path $tempDir 'failure.log'
   Write-Debug "Looking for failure log at `'$failureLog`'"

--- a/src/functions/Get-ChocolateyTempDir.ps1
+++ b/src/functions/Get-ChocolateyTempDir.ps1
@@ -1,0 +1,6 @@
+function Get-ChocolateyTempDir {
+  Write-Debug "Running 'Get-ChocolateyTempDir'";
+
+  $chocTempDir = Join-Path (Get-TempDir) "chocolatey"
+  return $chocTempDir
+}

--- a/src/functions/Get-ConfigValue.ps1
+++ b/src/functions/Get-ConfigValue.ps1
@@ -2,9 +2,10 @@ function Get-ConfigValue {
 param(
   [Parameter(Mandatory = $true)]
   [ValidateNotNullOrEmpty()]
-  [string] $configValue
+  [string] $configValue,
+  [string] $defaultValue
 )
-  Write-Debug "Running 'Get-ConfigValue' with configValue:`'$configValue`'";
+  Write-Debug "Running 'Get-ConfigValue' with configValue:`'$configValue`', defaultValue:`'$defaultValue`'";
 
   $returnValue = Get-UserConfigValue $configValue
   Write-Debug "After checking the user config the value of `'$configValue`' is `'$returnValue`'"
@@ -17,8 +18,13 @@ param(
   }
 
   if ($returnValue -eq $null) {
-      Write-Error "A configuration value for $configValue was not found"
+    if ($defaultValue -eq $null) {
+      Write-Error "A configuration value for $configValue was not found and no default was specified"
+    }
+
+    Write-Debug "Neither the user nor global config specified a value for `'$configValue`'. Using the default value: `'$defaultValue`'"
+    $returnValue = $defaultValue
   }
 
-  $returnValue
+  return $returnValue
 }

--- a/src/functions/Get-TempDir.ps1
+++ b/src/functions/Get-TempDir.ps1
@@ -1,0 +1,7 @@
+function Get-TempDir {
+  Write-Debug "Running 'Get-TempDir'"
+
+  $tempDir = Get-ConfigValue 'tempDir' $env:TEMP
+  $tempDir = [Environment]::ExpandEnvironmentVariables($tempDir)
+  return $tempDir
+}

--- a/src/functions/Run-ChocolateyPS1.ps1
+++ b/src/functions/Run-ChocolateyPS1.ps1
@@ -44,7 +44,7 @@ param(
       ##testing Start-Process -FilePath "powershell.exe" -ArgumentList " -noexit `"$ps1FullPath`"" -Verb "runas"  -Wait  #-PassThru -UseNewEnvironment ##-RedirectStandardError $errorLog -WindowStyle Normal
 
       #detect errors
-      $chocTempDir = Join-Path $env:TEMP "chocolatey"
+      $chocTempDir = Get-ChocolateyTempDir
       $tempDir = Join-Path $chocTempDir "$packageName"
       $failureLog = Join-Path $tempDir 'failure.log'
       if ([System.IO.File]::Exists($failureLog)) {

--- a/src/helpers/functions/Install-ChocolateyPackage.ps1
+++ b/src/helpers/functions/Install-ChocolateyPackage.ps1
@@ -70,7 +70,7 @@ param(
   try {
     Write-Debug "Running 'Install-ChocolateyPackage' for $packageName with url:`'$url`', args: `'$silentArgs`', fileType: `'$fileType`', url64bit: `'$url64bit`', checksum: `'$checksum`', checksumType: `'$checksumType`', checksum64: `'$checksum64`', checksumType64: `'$checksumType64`', validExitCodes: `'$validExitCodes`' ";
 
-    $chocTempDir = Join-Path $env:TEMP "chocolatey"
+    $chocTempDir = Get-ChocolateyTempDir
     $tempDir = Join-Path $chocTempDir "$packageName"
 
     if (![System.IO.Directory]::Exists($tempDir)) { [System.IO.Directory]::CreateDirectory($tempDir) | Out-Null }

--- a/src/helpers/functions/Install-ChocolateyVsixPackage.ps1
+++ b/src/helpers/functions/Install-ChocolateyVsixPackage.ps1
@@ -71,7 +71,7 @@ param(
         $installer = Join-Path $dir "VsixInstaller.exe"
     }
     if($installer) {
-        $download="$env:temp\$($packageName.Replace(' ','')).vsix"
+        $download="$(Get-TempDir)\$($packageName.Replace(' ','')).vsix"
         try{
             Get-ChocolateyWebFile $packageName $download $vsixUrl -checksum $checksum -checksumType $checksumType
         }

--- a/src/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -61,7 +61,7 @@ param(
   try {
     $fileType = 'zip'
 
-    $chocTempDir = Join-Path $env:TEMP "chocolatey"
+    $chocTempDir = Get-ChocolateyTempDir
     $tempDir = Join-Path $chocTempDir "$packageName"
     if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir) | Out-Null}
     $file = Join-Path $tempDir "$($packageName)Install.$fileType"

--- a/src/helpers/functions/Write-ChocolateyFailure.ps1
+++ b/src/helpers/functions/Write-ChocolateyFailure.ps1
@@ -4,7 +4,7 @@ param(
   [string] $failureMessage
 )
 
-  $chocTempDir = Join-Path $env:TEMP "chocolatey"
+  $chocTempDir = Get-ChocolateyTempDir
   $tempDir = Join-Path $chocTempDir "$packageName"
   if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
   $successLog = Join-Path $tempDir 'success.log'

--- a/src/helpers/functions/Write-ChocolateySuccess.ps1
+++ b/src/helpers/functions/Write-ChocolateySuccess.ps1
@@ -3,7 +3,7 @@ param(
   [string] $packageName
 )
 
-  $chocTempDir = Join-Path $env:TEMP "chocolatey"
+  $chocTempDir = Get-ChocolateyTempDir
   $tempDir = Join-Path $chocTempDir "$packageName"
   if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
 

--- a/tests/unit/Get-ChecksumValid.tests.ps1
+++ b/tests/unit/Get-ChecksumValid.tests.ps1
@@ -7,7 +7,7 @@ function setup-testfile {
   $filePath = 'some\file.txt'
   Setup -File "$filePath" 'yo yo'
 
-  Join-Path (Join-Path $env:Temp 'pester') "$filePath"
+  Join-Path (Join-Path (Get-TempDir) 'pester') "$filePath"
 }
 
   Context "When a good checksum is provided" {

--- a/tests/unit/Get-ConfigValue.tests.ps1
+++ b/tests/unit/Get-ConfigValue.tests.ps1
@@ -25,6 +25,38 @@ Describe "Get-ConfigValue" {
     }
   }
 
+  Context "when retrieving an unspecified value with a default" {
+    $oldProfile = $env:USERPROFILE
+    $env:USERPROFILE = Join-Path 'TestDrive:' 'userProfile'
+    Setup -File 'chocolatey\chocolateyInstall\chocolatey.config' @"
+<?xml version="1.0"?>
+<chocolatey />
+"@
+    $result = Get-ConfigValue 'checksumFiles' $false
+    $env:USERPROFILE = $oldProfile
+
+    It "should return the default value" {
+      $result  | should Be 'false'
+    }
+  }
+
+Context "when retrieving an configured value with a default" {
+    $oldProfile = $env:USERPROFILE
+    $env:USERPROFILE = Join-Path 'TestDrive:' 'userProfile'
+    Setup -File 'chocolatey\chocolateyInstall\chocolatey.config' @"
+<?xml version="1.0"?>
+<chocolatey>
+  <checksumFiles>true</checksumFiles>
+</chocolatey>
+"@
+    $result = Get-ConfigValue 'checksumFiles' $false
+    $env:USERPROFILE = $oldProfile
+
+    It "should return the configured value" {
+      $result  | should Be 'true'
+    }
+  }
+
   Context "when retrieving a list" {
     $oldProfile = $env:USERPROFILE
     $env:USERPROFILE = Join-Path 'TestDrive:' 'userProfile'

--- a/tests/unit/Get-TempDir.tests.ps1
+++ b/tests/unit/Get-TempDir.tests.ps1
@@ -1,0 +1,39 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$common = Join-Path (Split-Path -Parent $here)  '_Common.ps1'
+. $common
+
+Setup -File 'userprofile\_crapworkaround.txt'
+Describe "Get-TempDir" {
+  Context "when retrieving the temp dir without a configured value" {
+    $oldProfile = $env:USERPROFILE
+    $env:USERPROFILE = Join-Path 'TestDrive:' 'userProfile'
+    Setup -File 'chocolatey\chocolateyInstall\chocolatey.config' @"
+<?xml version="1.0"?>
+<chocolatey />
+"@
+    $result = Get-TempDir
+    $env:USERPROFILE = $oldProfile
+
+    It "should return the default temp directory %TEMP%" {
+      $result  | should Be $env:TEMP
+    }
+  }
+
+  Context "when retrieving the temp dir with a configured value" {
+      $oldProfile = $env:USERPROFILE
+      $env:USERPROFILE = Join-Path 'TestDrive:' 'userProfile'
+      Setup -File 'chocolatey\chocolateyInstall\chocolatey.config' @"
+<?xml version="1.0"?>
+<chocolatey>
+  <tempDir>%USERPROFILE%\TEMP</tempDir>
+</chocolatey>
+"@
+    $result = Get-TempDir
+    $expectedResult = Join-Path $env:USERPROFILE 'TEMP'
+    $env:USERPROFILE = $oldProfile
+
+    It "should return the configured temp directory %USERPROFILE%\TEMP" {
+      $result  | should Be $expectedResult
+    }
+  }
+}

--- a/tests/unit/Install-ChocolateyVsixPackage.Tests.ps1
+++ b/tests/unit/Install-ChocolateyVsixPackage.Tests.ps1
@@ -137,7 +137,7 @@ Describe "Install-ChocolateyVsixPackage" {
 
     Install-ChocolateyVsixPackage "package name" "url"
     It "should remove spaces" {
-        Assert-MockCalled Install-Vsix -ParameterFilter {$installFile -eq "$env:temp\packagename.vsix"}
+        Assert-MockCalled Install-Vsix -ParameterFilter {$installFile -eq "$(Get-TempDir)\packagename.vsix"}
     }
   }
 }

--- a/tests/unit/Run-ChocolateyPS1.tests.ps1
+++ b/tests/unit/Run-ChocolateyPS1.tests.ps1
@@ -9,8 +9,8 @@ function ChocolateyInstall {
 
   Context "with installer arguments" {
     $cmd=(Get-Command ChocolateyInstall)
-    Mock Get-ChildItem { return @{Name="chocolateyinstall.ps1";FullName=$cmd} } -ParameterFilter { $path -eq "$env:temp\test" }
-    Run-ChocolateyPS1 "$env:temp\test" 'testPackage' 'install' 'real args'
+    Mock Get-ChildItem { return @{Name="chocolateyinstall.ps1";FullName=$cmd} } -ParameterFilter { $path -eq "$(Get-TempDir)\test" }
+    Run-ChocolateyPS1 "$(Get-TempDir)\test" 'testPackage' 'install' 'real args'
 
     It "should set chocolateyInstallArguments env var to Installer Arguments" {
       $global:installArgsInEnvironment  | should Be 'real args'


### PR DESCRIPTION
Enable users to specify an alternate temp directory in the chocolatey configuration.
If <tempDir> is not present, then $env:TEMP is used as a default.

This enables companies with IT policies that prevent executing files
in the %TEMP% directory to continue to use Chocolatey (see discussion at https://groups.google.com/forum/#!topic/chocolatey/V8aU7VnB5eM)

Sample Configuration File with value specified:

    <?xml version="1.0"?>
    <chocolatey>

        <tempDir>%ProgramData%\Chocolatey\Temp</tempDir>
    
        <useNuGetForSources>false</useNuGetForSources>
        <checksumFiles>true</checksumFiles>
        <virusCheck>false</virusCheck>
        <sources>
            <source id="chocolatey" value="https://chocolatey.org/api/v2/" />
        </sources>
    </chocolatey>