### PR TITLE
add label to new file types in the Install-ChocolateyFileAssociation command and enhancements to Start-ChocolateyProcessAsAdmin

### DIFF
--- a/src/helpers/functions/Install-ChocolateyFileAssociation.ps1
+++ b/src/helpers/functions/Install-ChocolateyFileAssociation.ps1
@@ -41,7 +41,12 @@ param(
   }
   $fileType = Split-Path $executable -leaf
   $fileType = $fileType.Replace(" ","_")
-  $elevated = "cmd /c 'assoc $extension=$fileType';cmd /c 'ftype $fileType=\`"$executable\`" \`"%1\`" \`"%*\`"'"
+  $elevated = @"
+    cmd /c "assoc $extension=$fileType"
+    cmd /c 'ftype $fileType="$executable" "%1" "%*"'
+    New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT
+    Set-ItemProperty -Path "HKCR:\$fileType" -Name "(Default)" -Value "$fileType file" -ErrorAction Stop
+"@
   Start-ChocolateyProcessAsAdmin $elevated
   Write-Host "`'$extension`' has been associated with `'$executable`'"
 }

--- a/src/helpers/functions/Start-ChocolateyProcessAsAdmin.ps1
+++ b/src/helpers/functions/Start-ChocolateyProcessAsAdmin.ps1
@@ -8,44 +8,74 @@ param(
 )
   Write-Debug "Running 'Start-ChocolateyProcessAsAdmin' with exeToRun:`'$exeToRun`', statements: `'$statements`' ";
 
-  $wrappedStatements = $statements;
+  $wrappedStatements = $statements
   if ($exeToRun -eq 'powershell') {
     $exeToRun = "$($env:windir)\System32\WindowsPowerShell\v1.0\powershell.exe"
-    if (!$statements.EndsWith(';')){$statements = $statements + ';'}
-    $importChocolateyHelpers = "";
+    $importChocolateyHelpers = ""
     Get-ChildItem "$helpersPath" -Filter *.psm1 | ForEach-Object { $importChocolateyHelpers = "& import-module -name  `'$($_.FullName)`';$importChocolateyHelpers" };
-    $wrappedStatements = "-NoProfile -ExecutionPolicy unrestricted -Command `"$importChocolateyHelpers try{$statements start-sleep 6;}catch{write-error `'That was not sucessful`';start-sleep 8;throw;}`""
-    if ($noSleep) {
-      $wrappedStatements = "-NoProfile -ExecutionPolicy unrestricted -Command `"$importChocolateyHelpers try{$statements}catch{write-error `'That was not sucessful`';throw;}`""
-    }
+    $block = @"
+      `$noSleep = `$$noSleep
+      $importChocolateyHelpers 
+      try{
+        `$progressPreference="SilentlyContinue"
+        $statements 
+        if(!`$noSleep){start-sleep 6}
+      }
+      catch{
+        if(!`$noSleep){start-sleep 8}
+        throw
+      }
+"@
+    $encoded = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($block))
+    $wrappedStatements = "-NoProfile -ExecutionPolicy bypass -EncodedCommand $encoded"
+    $dbgMessage = @"
+Elevating Permissions and running powershell block:
+$block 
+This may take a while, depending on the statements.
+"@
   }
-@"
+  else {
+    $dbgMessage = @"
 Elevating Permissions and running $exeToRun $wrappedStatements. This may take a while, depending on the statements.
-"@ | Write-Debug
+"@
+  }
+  $dbgMessage | Write-Debug
 
-  $psi = new-object System.Diagnostics.ProcessStartInfo;
-  $psi.FileName = $exeToRun;
+  $psi = new-object System.Diagnostics.ProcessStartInfo
+  $psi.RedirectStandardError = $true
+  $psi.UseShellExecute = $false
+  $psi.FileName = $exeToRun
   if ($wrappedStatements -ne '') {
-    $psi.Arguments = "$wrappedStatements";
+    $psi.Arguments = "$wrappedStatements"
   }
 
   if ([Environment]::OSVersion.Version -ge (new-object 'Version' 6,0)){
-    $psi.Verb = "runas";
+    $psi.Verb = "runas"
   }
 
-  $psi.WorkingDirectory = get-location;
+  $psi.WorkingDirectory = get-location
 
   if ($minimized) {
-    $psi.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Minimized;
+    $psi.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Minimized
   }
 
-  $s = [System.Diagnostics.Process]::Start($psi);
-  $s.WaitForExit();
+  $s = [System.Diagnostics.Process]::Start($psi)
+
+  $chocTempDir = Join-Path $env:TEMP "chocolatey"
+  $errorFile = Join-Path $chocTempDir "$($s.Id)-error.stream"
+  $s.StandardError.ReadToEnd() | Out-File $errorFile
+  $s.WaitForExit()
   if ($validExitCodes -notcontains $s.ExitCode) {
-    $errorMessage = "[ERROR] Running $exeToRun with $statements was not successful. Exit code was `'$($s.ExitCode)`'."
-    Write-Error $errorMessage
+    try {
+      $innerError = Import-CLIXML $errorFile | ? { $_.GetType() -eq [String] } | Out-String
+    }
+    catch{
+      $innerError = Get-Content $errorFile | Out-String
+    }
+    $errorMessage = "[ERROR] Running $exeToRun with $statements was not successful. Exit code was `'$($s.ExitCode)`' Error Message: $innerError."
+    Remove-Item $errorFile -Force -ErrorAction SilentlyContinue
     throw $errorMessage
   }
 
-  Write-Debug "Finishing 'Start-ChocolateyProcessAsAdmin'";
+  Write-Debug "Finishing 'Start-ChocolateyProcessAsAdmin'"
 }


### PR DESCRIPTION
This includes a fix to the Install-ChocolateyFileAssociation command to prevent the windows explorer New Item context menu from having items removed when this command replaces file extensions with new types.

More significantly this makes Start-ChocolateyProcessAsAdmin easier to work with by:
1. Encoding the command string to reduce the coding friction around nested quotes and multi line powershell blocks. As can be seen from Install-ChocolateyFileAssociation, I can now construct my elevated script using an easier to read and write here string.
1. Do a better job of capturing errors from the elevated script and bubbling them back up to the package error. While testing with the Install-ChocolateyFileAssociation command, My script raised an error that I would see appear and then disappear. The final error and what was in the log simply tells me there is an error. This dumps the standard error stream of the elevated process to a file. If the process was a powershell process the stream is output as CLIXML and this will deserialize that to its human readable form.
2. This removes duplicate errors. I still noticed a duplicate error after these changes but there were far fewer than before.

I realize this change is fairly significant and if others dont see the value add here, I'm happy to resubmit with just the File Association specific changes.
