### PR TITLE
Added quotes around 'update file' when running wusa.exe.

### DIFF
--- a/src/helpers/functions/Install-ChocolateyInstallPackage.ps1
+++ b/src/helpers/functions/Install-ChocolateyInstallPackage.ps1
@@ -81,7 +81,8 @@ param(
   }
 
   if($fileType -like 'msu') {
-
+    #Quote the path
+    $file = "`"$((resolve-path $file).Path)`""
     if ($overrideArguments) {
       $msuArgs = "$file $additionalInstallArgs"
     } else {


### PR DESCRIPTION
Added quotes around update file (if they aren't already there) for cases when there is a space in the path or the package name has a space.  I noticed this was breaking when  my install script used a package name with space.
