### PR TITLE
Initial support for .run packages. 

### DIFF
--- a/src/chocolatey.ps1
+++ b/src/chocolatey.ps1
@@ -50,6 +50,7 @@ $nugetPath = (Split-Path -Parent $nugetChocolateyPath)
 $nugetExePath = Join-Path $nuGetPath 'bin'
 $nugetLibPath = Join-Path $nuGetPath 'lib'
 $badLibPath = Join-Path $nuGetPath 'lib-bad'
+$runLibPath = Join-Path $nuGetPath 'lib-run'
 $extensionsPath = Join-Path $nugetPath 'extensions'
 $chocInstallVariableName = "ChocolateyInstall"
 $nugetExe = Join-Path $nugetChocolateyPath 'nuget.exe'

--- a/src/functions/Run-NuGet.ps1
+++ b/src/functions/Run-NuGet.ps1
@@ -2,14 +2,15 @@
 param(
   [string] $packageName,
   [string] $source = '',
-  [string] $version = ''
-)
+  [string] $version = '',
+  [string] $nugetInstallPath=$nugetLibPath)
+
   Write-Debug "Running 'Run-NuGet' for $packageName with source: `'$source`', version:`'$version`'";
   Write-Debug "___ NuGet ____"
 
   $srcArgs = Get-SourceArguments $source
 
-  $packageArgs = "install $packageName -OutputDirectory `"$nugetLibPath`" $srcArgs -NonInteractive -NoCache"
+  $packageArgs = "install $packageName -OutputDirectory `"$nugetInstallPath`" $srcArgs -NonInteractive -NoCache"
   if ($version -notlike '') {
     $packageArgs = $packageArgs + " -Version $version";
   }


### PR DESCRIPTION
.run Packages ara packages that are not "installed", effectively turning them into script-packages. The packages are not installed to lib\ folder, but in every other aspects they are identical to ordinary packages.

**When a package has the extension '.run' this happens upon install:**
  1. The package is downloaded to lib-run
  2. tools\chocolateyinstall.ps1 script is executed
  3. Package is removed from lib-run

One of the main advantages of .run packages as part of Chocolatey is dependencies. .run packages can depend on ordinary packages (or other .run packages). Ordinary packages can depend on .run packages.

Scenario 1 - *AdvancedScriptPackage.run*
* Depends on *scriptcs*. 
* Includes AdvancedScript.cs in tools folder. 
* chocolateyinstall.ps1 does nothing but invoke 'scriptcs AdvancedScript.cs'.

Scenario 2 - *CustomBusinessApplication* (ordinary package) 
* Depends on *EnsureComputerMeetsCorporateStandards.run*
* Depends on *CleanUpOldLegacyApplication.run*

I have done basic testing, and the changes seems to be working as intended.

If necessary I can do more testing and try to write some unit tests.