### PR TITLE
write to the correctly scoped chocolateyErrored variable

### DIFF
--- a/src/chocolatey.ps1
+++ b/src/chocolatey.ps1
@@ -166,7 +166,7 @@ if ($forceX86) {
 
 $env:chocolateyPackageParameters = $packageParameters
 
-$chocolateyErrored = $false
+$script:chocolateyErrored = $false
 $badPackages = ''
 
 #todo: This does not catch package names that come later
@@ -193,7 +193,7 @@ foreach ($packageName in $packageNames) {
     }
   }
   catch {
-    $chocolateyErrored = $true
+    $script:chocolateyErrored = $true
     Write-Host "$($_.Exception.Message)" -BackgroundColor $ErrorColor -ForegroundColor White ;
     if ($badPackages -ne '') { $badPackages += ', '}
     $badPackages += "$packageName"
@@ -208,7 +208,7 @@ if ($badPackages -ne '') {
  Write-Host "Command `'$command`' failed (sometimes this indicates a partial failure). Additional info/packages: $badpackages" -BackgroundColor $ErrorColor -ForegroundColor White
 }
 
-if ($chocolateyErrored) {
+if ($script:chocolateyErrored) {
   Write-Debug "Exiting with non-zero exit code."
   exit 1
 }

--- a/src/functions/Chocolatey-NuGet.ps1
+++ b/src/functions/Chocolatey-NuGet.ps1
@@ -76,7 +76,7 @@ Write-Debug "Installing packages to `"$nugetLibPath`"."
             Write-Host " "
             Write-Host "$installedPackageName v$installedPackageVersion" -ForegroundColor $Note -BackgroundColor Black
 
-            if ([System.IO.Directory]::Exists($packageFolder)) {
+            if (Test-Path $packageFolder) {
               try {
                 Delete-ExistingErrorLog $installedPackageName
                 Run-ChocolateyPS1 $packageFolder $installedPackageName "install" $installerArguments
@@ -90,7 +90,7 @@ Write-Debug "Installing packages to `"$nugetLibPath`"."
                 Write-Error "Package `'$installedPackageName v$installedPackageVersion`' did not install successfully: $($_.Exception.Message)"
                 if ($badPackages -ne '') { $badPackages += ', '}
                 $badPackages += "$packageName"
-                $chocolateyErrored = $true
+                $script:chocolateyErrored = $true
               }
             }
           }

--- a/tests/unit/Chocolatey-NuGet.tests.ps1
+++ b/tests/unit/Chocolatey-NuGet.tests.ps1
@@ -1,6 +1,7 @@
 $here = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $common = Join-Path (Split-Path -Parent $here)  '_Common.ps1'
 . $common
+$chocolateyErrored = $false
 
 Describe "Chocolatey-NuGet" {
   Context "under normal circumstances" {
@@ -14,6 +15,22 @@ Describe "Chocolatey-NuGet" {
 
     It "should call Update-SessionEnvironment" {
       Assert-MockCalled Update-SessionEnvironment
+    }
+  }
+
+  Context "chocolateyPS1 throws an error" {
+    $nugetLibPath = "c:\fake-lib"
+    Mock Update-SessionEnvironment
+    Mock Run-NuGet {"Successfully installed 'somepackage 1.0.0'"} -Verifiable -ParameterFilter {$packageName -eq 'somepackage'}
+    Mock Run-ChocolateyPS1 { throw "big bad error" }
+    Mock Test-Path { $true } -ParameterFilter {$path -eq 'c:\fake-lib\somepackage.1.0.0'}
+    Mock Move-BadInstall
+    Mock Write-Error
+
+    Chocolatey-NuGet 'somepackage'
+
+    It "should set chocolateyErrored to true" {
+      $chocolateyErrored | should be $true
     }
   }
 


### PR DESCRIPTION
Exceptions raised in chocolateyInstall.ps1 are not resulting in a non-zero exit code because it is writing to the `$chocolateyErrored` variable in a different scope from where it was created. To illustrate, the added test in this PR will fail if `Chocolatey-Nuget.ps1` is reverted.