### PR TITLE
Treat $chocolateyErrored as a global variable, to ensure it bubbles up

### DIFF
--- a/src/chocolatey.ps1
+++ b/src/chocolatey.ps1
@@ -166,7 +166,7 @@ if ($forceX86) {
 
 $env:chocolateyPackageParameters = $packageParameters
 
-$chocolateyErrored = $false
+$global:chocolateyErrored = $false
 $badPackages = ''
 
 #todo: This does not catch package names that come later
@@ -193,7 +193,7 @@ foreach ($packageName in $packageNames) {
     }
   }
   catch {
-    $chocolateyErrored = $true
+    $global:chocolateyErrored = $true
     Write-Host "$($_.Exception.Message)" -BackgroundColor $ErrorColor -ForegroundColor White ;
     if ($badPackages -ne '') { $badPackages += ', '}
     $badPackages += "$packageName"
@@ -208,7 +208,7 @@ if ($badPackages -ne '') {
  Write-Host "Command `'$command`' failed (sometimes this indicates a partial failure). Additional info/packages: $badpackages" -BackgroundColor $ErrorColor -ForegroundColor White
 }
 
-if ($chocolateyErrored) {
+if ($global:chocolateyErrored) {
   Write-Debug "Exiting with non-zero exit code."
   exit 1
 }

--- a/src/functions/Chocolatey-NuGet.ps1
+++ b/src/functions/Chocolatey-NuGet.ps1
@@ -90,7 +90,7 @@ Write-Debug "Installing packages to `"$nugetLibPath`"."
                 Write-Error "Package `'$installedPackageName v$installedPackageVersion`' did not install successfully: $($_.Exception.Message)"
                 if ($badPackages -ne '') { $badPackages += ', '}
                 $badPackages += "$packageName"
-                $chocolateyErrored = $true
+                $global:chocolateyErrored = $true
               }
             }
           }
@@ -100,5 +100,11 @@ Write-Debug "Installing packages to `"$nugetLibPath`"."
   }
 
   Update-SessionEnvironment
-  Write-Host "Finished installing `'$packageName`' and dependencies - if errors not shown in console, none detected. Check log for errors if unsure." -ForegroundColor $RunNote -BackgroundColor Black
+
+  if ($global:chocolateyErrored) {
+    Write-Host "Failed to install `'$packageName`' or dependencies"
+  }
+  else {
+    Write-Host "Finished installing `'$packageName`' and dependencies - if errors not shown in console, none detected. Check log for errors if unsure." -ForegroundColor $RunNote -BackgroundColor Black
+  }
 }


### PR DESCRIPTION
Fixes chocolatey/chocolatey#663

$chocolatelyErrored was being treated by powershell as multiple local variables, so it was losing its value when it exited Chocolatey-Nuget.ps1.