### PR TITLE
(bug) removed setting url64bit to url by default

### DIFF
--- a/src/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -49,7 +49,7 @@ param(
   [string] $packageName,
   [string] $url,
   [string] $unzipLocation,
-  [string] $url64bit = $url,
+  [string] $url64bit = '',
   [string] $specificFolder ="",
   [string] $checksum = '',
   [string] $checksumType = '',


### PR DESCRIPTION
I'm not sure why $url64bit is being set to $url; what is being accomplished here?

Reasons for fix
1. Checksums don't work as expected; a 32-bit URL on a 64-bit system will pull the 64-bit URL so choco expects -checksum64 to be set and if $checksum64 != $checksum, the install will fail.
2. Related issue #590 