### PR TITLE
updating install script to have parameter for chocolatey version.

### DIFF
--- a/chocolateyInstall/InstallChocolatey.ps1
+++ b/chocolateyInstall/InstallChocolatey.ps1
@@ -1,3 +1,6 @@
+Param(
+  [string]$chocolateyVersion = ""
+)
 # ==============================================================================
 #
 # Fervent Coder Copyright 2011 - Present - Released under the Apache 2.0 License
@@ -17,9 +20,8 @@
 # ==============================================================================
 
 # variables
-#$url = "https://chocolatey.org/packages/chocolatey/DownloadPackage"
-$url = "https://chocolatey.org/api/v2/package/chocolatey/"
-#$url = "https://chocolatey.org/api/v1/package/chocolatey"
+if (![string]::IsNullOrEmpty($chocolateyVersion)){Write-Host "Downloading specific version of Chocolatey: " + $chocolateyVersion}
+$url = "https://chocolatey.org/api/v2/package/chocolatey/" + $chocolateyVersion
 $chocTempDir = Join-Path $env:TEMP "chocolatey"
 $tempDir = Join-Path $chocTempDir "chocInstall"
 if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
@@ -44,16 +46,16 @@ $chocInstallPS1 = Join-Path $toolsFolder "chocolateyInstall.ps1"
 
 & $chocInstallPS1
 
-write-host 'Ensuring chocolatey commands are on the path'
+Write-Host "Ensuring chocolatey commands are on the path"
 $chocInstallVariableName = "ChocolateyInstall"
 $nuGetPath = [Environment]::GetEnvironmentVariable($chocInstallVariableName, [System.EnvironmentVariableTarget]::User)
-$nugetExePath = 'C:\ProgramData\Chocolatey\bin'
+$nugetExePath = "C:\ProgramData\Chocolatey\bin"
 if ($nuGetPath -ne $null) {
-  $nugetExePath = Join-Path $nuGetPath 'bin'
+  $nugetExePath = Join-Path $nuGetPath "bin"
 }
 
 if ($($env:Path).ToLower().Contains($($nugetExePath).ToLower()) -eq $false) {
-  $env:Path = [Environment]::GetEnvironmentVariable('Path',[System.EnvironmentVariableTarget]::Machine);
+  $env:Path = [Environment]::GetEnvironmentVariable("Path",[System.EnvironmentVariableTarget]::Machine);
 }
 Write-Host "THIS IS DEPRECATED. Please use the install from https://chocolatey.org/install.ps1"
 # update chocolatey to the latest version


### PR DESCRIPTION
I had a client that needed to test multiple versions of chocolatey for validation of their software packages.  In the process, it made sense to push this back to the team as it's a pretty basic change.  I updated the URL such that it optionally adds a version number to the URI in accordance with the v2 chocolatey.org API.  This has the consequence of downloading the latest when the powershell script is run as-is and additionally accepts a parameter of -chocolateyVersion to specify the full version # as specified here: https://chocolatey.org/packages/chocolatey/#versionhistory

